### PR TITLE
Update default migration version to include retryable column

### DIFF
--- a/lib/generators/que/templates/add_que.rb
+++ b/lib/generators/que/templates/add_que.rb
@@ -1,7 +1,7 @@
 class AddQue < ActiveRecord::Migration
   def self.up
     # The current version as of this migration's creation.
-    Que.migrate! :version => 3
+    Que.migrate! :version => 4
   end
 
   def self.down


### PR DESCRIPTION
That. Means `rails generate que:install` will include the `retryable` column.