### PR TITLE
Enforce serialization on synchronous jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.11.7 (2017-05-01)
+
+*   Serialize and de-serialize job args when Que.mode = :sync  (lawrencejones)
+
 ### 0.11.6 (2016-07-01)
 
 *   Fix for operating in nested transactions in Rails 5.0. (#160) (greysteil)

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -77,7 +77,7 @@ module Que
         end
 
         if Que.mode == :sync && !t
-          run(*attrs[:args])
+          run(*JSON.parse(attrs[:args].to_json))
         else
           values = Que.execute(:insert_job, attrs.values_at(:queue, :priority, :run_at, :job_class, :retryable, :args)).first
           Que.adapter.wake_worker_after_commit unless t

--- a/lib/que/version.rb
+++ b/lib/que/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Que
-  Version = '0.11.6'
+  Version = '0.11.7'
 end

--- a/spec/unit/pool_spec.rb
+++ b/spec/unit/pool_spec.rb
@@ -59,7 +59,7 @@ describe "Managing the Worker pool" do
         Que.mode = :sync
 
         ArgsJob.enqueue(5, :testing => "synchronous").should be_an_instance_of ArgsJob
-        $passed_args.should == [5, {:testing => "synchronous"}]
+        $passed_args.should == [5, {"testing" => "synchronous"}]
         DB[:que_jobs].count.should be 0
       end
 
@@ -68,7 +68,7 @@ describe "Managing the Worker pool" do
         Que.mode = :sync
 
         ArgsJob.enqueue(5, :testing => "synchronous").should be_an_instance_of ArgsJob
-        $passed_args.should == [5, {:testing => "synchronous"}]
+        $passed_args.should == [5, {"testing" => "synchronous"}]
       end
 
       it "should not affect jobs that are queued with specific run_ats" do


### PR DESCRIPTION
Que should handle job arguments in a consistent manner regardless of
Que.mode. In the past when Que.mode is :sync then Que calls the run
method with whatever you have passed- this means arguments such as
symbol hashes (`{key: 'value'}`) would be passed unchanged, while if
this was enqueued and picked up by a Que worker from the database, the
hash would have string keys (`{'key' => 'value'}`).

The usage of Que.mode :sync is really reserved for testing environments,
where handling job args differently from how they will be used in
production can make tests pass when really they should fail. This change
makes Que fully serialize and then deserialize the job arguments to
ensure we run jobs with the arguments they will see in production.