### PR TITLE
Use JSON_MODULE for serialization over #to_json

### DIFF
--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -77,7 +77,7 @@ module Que
         end
 
         if Que.mode == :sync && !t
-          run(*JSON.parse(attrs[:args].to_json))
+          run(*JSON.parse(JSON_MODULE.dump(attrs[:args])))
         else
           values = Que.execute(:insert_job, attrs.values_at(:queue, :priority, :run_at, :job_class, :retryable, :args)).first
           Que.adapter.wake_worker_after_commit unless t


### PR DESCRIPTION
The #to_json method behaves strangely if anything in that chain has been
added to. Use JSON_MODULE to be consistent with how Que serialises Job
args internally.