### PR TITLE
Remove JSON.load/dump in favour of parse/generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Unreleased
+### 0.11.7 (2017-06-01)
 
 *   Fix security vulnerability in parsing JSON from the DB (by specifying create_additions: false). This shouldn't be a concern unless you were passing untrusted user input in your job arguments. (hmac)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+*   Fix security vulnerability in parsing JSON from the DB (by specifying create_additions: false). This shouldn't be a concern unless you were passing untrusted user input in your job arguments. (hmac)
+
 ### 0.11.6 (2016-07-01)
 
 *   Fix for operating in nested transactions in Rails 5.0. (#160) (greysteil)

--- a/lib/que/adapters/base.rb
+++ b/lib/que/adapters/base.rb
@@ -102,7 +102,7 @@ module Que
       CAST_PROCS[1184] = Time.method(:parse)
 
       # JSON.
-      CAST_PROCS[114] = JSON_MODULE.method(:load)
+      CAST_PROCS[114] = -> (value) { JSON_MODULE.load(value, create_additions: false) }
 
       # Boolean:
       CAST_PROCS[16] = 't'.method(:==)

--- a/lib/que/version.rb
+++ b/lib/que/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Que
-  Version = '0.11.6'
+  Version = '0.11.7'
 end


### PR DESCRIPTION
Cherry-picked from upstream; this fixes a security vuln where untrusted user input as job args could instantiate arbitrary Ruby classes.