### PR TITLE
Serialise and deserialise job args in sync mode

### DIFF
--- a/spec/unit/pool_spec.rb
+++ b/spec/unit/pool_spec.rb
@@ -59,7 +59,7 @@ describe "Managing the Worker pool" do
         Que.mode = :sync
 
         ArgsJob.enqueue(5, :testing => "synchronous").should be_an_instance_of ArgsJob
-        $passed_args.should == [5, {:testing => "synchronous"}]
+        $passed_args.should == [5, {"testing" => "synchronous"}]
         DB[:que_jobs].count.should be 0
       end
 
@@ -68,7 +68,7 @@ describe "Managing the Worker pool" do
         Que.mode = :sync
 
         ArgsJob.enqueue(5, :testing => "synchronous").should be_an_instance_of ArgsJob
-        $passed_args.should == [5, {:testing => "synchronous"}]
+        $passed_args.should == [5, {"testing" => "synchronous"}]
       end
 
       it "should not affect jobs that are queued with specific run_ats" do


### PR DESCRIPTION
When setting `Que.mode = :sync`  arguments that are passed to a job may not be the same to the ones that are passed when `Que.mode = :async`. For example, passing a `Time` in `async` mode will result in the job receiving a string, however, in `sync` mode the job will receive a `Time`.

To ensure that `sync` mode matches the behaviour of `async` mode, we must:

- serialise the job arguments
- deserialise the job arguments
- run the `Que.json_converter`