### PR TITLE
Pin Rake to < 11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'rake'
+  gem 'rake', '< 11.0'
 
   gem 'activerecord',    :require => nil
   gem 'sequel',          :require => nil


### PR DESCRIPTION
Rake 11.0.1 removes the `last_comment` method which was required by `rspec-core`, so if we pin to a lower version the build should run.