### PR TITLE
[DNM] priority_threshold

### DIFF
--- a/bin/que
+++ b/bin/que
@@ -73,6 +73,10 @@ Que.worker_count  = (options.worker_count  || ENV['QUE_WORKER_COUNT']  || Que.wo
 Que.wake_interval = (options.wake_interval || ENV['QUE_WAKE_INTERVAL'] || Que.wake_interval || 0.1).to_f
 Que.mode          = :async
 
+# Supported in a custom feature branch for GC that will never be merged- use at your
+# peril!
+Que.priority_threshold = ENV.fetch('QUE_PRIORITY_THRESHOLD', 0).to_i
+
 stop = false
 %w(INT TERM).each { |signal| trap(signal) { stop = true } }
 

--- a/lib/que.rb
+++ b/lib/que.rb
@@ -171,7 +171,7 @@ module Que
     end
 
     # Copy some of the Worker class' config methods here for convenience.
-    [:mode, :mode=, :worker_count, :worker_count=, :wake_interval, :wake_interval=, :queue_name, :queue_name=, :wake!, :wake_all!].each do |meth|
+    [:mode, :mode=, :worker_count, :worker_count=, :wake_interval, :wake_interval=, :priority_threshold, :priority_threshold=, :queue_name, :queue_name=, :wake!, :wake_all!].each do |meth|
       define_method(meth) { |*args| Worker.send(meth, *args) }
     end
   end

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -99,14 +99,22 @@ module Que
         new(:args => args).tap { |job| job.run(*args) }
       end
 
-      def work(queue = '')
+      # We've introduced priority_threshold at GC to facilitate our transition from
+      # Softlayer to GCP. By providing Que with a priority threshold, we can configure
+      # workers in GCP to select an adjustable quantity of our job queue, in increasing
+      # priority order.
+      #
+      # This change should never be merged to master, as no one external to GC should ever
+      # have need of this functionality (I should think?). Regardless, the next change to
+      # Que should be merging the on-going refactor, which won't include this change.
+      def work(queue = '', priority_threshold = 0)
         # Since we're taking session-level advisory locks, we have to hold the
         # same connection throughout the process of getting a job, working it,
         # deleting it, and removing the lock.
         return_value =
           Que.adapter.checkout do
             begin
-              if job = Que.execute(:lock_job, [queue]).first
+              if job = Que.execute(:lock_job, [queue, priority_threshold]).first
                 # Edge case: It's possible for the lock_job query to have
                 # grabbed a job that's already been worked, if it took its MVCC
                 # snapshot while the job was processing, but didn't attempt the

--- a/lib/que/rake_tasks.rb
+++ b/lib/que/rake_tasks.rb
@@ -19,7 +19,13 @@ namespace :que do
     Que.worker_count  = (ENV['QUE_WORKER_COUNT'] || 4).to_i
     Que.wake_interval = (ENV['QUE_WAKE_INTERVAL'] || 0.1).to_f
     Que.queue_name    = ENV['QUE_QUEUE'] if ENV['QUE_QUEUE']
-    Que.mode          = :async
+
+    # Supported in a custom feature branch for GC that will never be merged- use at your
+    # peril!
+    Que.priority_threshold = ENV.fetch('QUE_PRIORITY_THRESHOLD', 0).to_i
+
+    # This starts the workers- all config needs to be placed before this.
+    Que.mode = :async
 
     # When changing how signals are caught, be sure to test the behavior with
     # the rake task in tasks/safe_shutdown.rb.

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -50,7 +50,7 @@ module Que
         FROM (
           SELECT j
           FROM que_jobs AS j
-          WHERE queue = $1::text
+          WHERE (queue = $1::text OR queue = '')
           AND run_at <= now()
           AND retryable = true
           AND priority > $2
@@ -63,7 +63,7 @@ module Que
             SELECT (
               SELECT j
               FROM que_jobs AS j
-              WHERE queue = $1::text
+              WHERE (queue = $1::text OR queue = '')
               AND run_at <= now()
               AND retryable = true
               AND priority > $2

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -53,6 +53,7 @@ module Que
           WHERE queue = $1::text
           AND run_at <= now()
           AND retryable = true
+          AND priority > $2
           ORDER BY priority, run_at, job_id
           LIMIT 1
         ) AS t1
@@ -65,6 +66,7 @@ module Que
               WHERE queue = $1::text
               AND run_at <= now()
               AND retryable = true
+              AND priority > $2
               AND (priority, run_at, job_id) > (jobs.priority, jobs.run_at, jobs.job_id)
               ORDER BY priority, run_at, job_id
               LIMIT 1

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -50,7 +50,7 @@ module Que
         FROM (
           SELECT j
           FROM que_jobs AS j
-          WHERE (queue = $1::text OR queue = '')
+          WHERE queue = $1::text
           AND run_at <= now()
           AND retryable = true
           AND priority > $2
@@ -63,7 +63,7 @@ module Que
             SELECT (
               SELECT j
               FROM que_jobs AS j
-              WHERE (queue = $1::text OR queue = '')
+              WHERE queue = $1::text
               AND run_at <= now()
               AND retryable = true
               AND priority > $2


### PR DESCRIPTION
Configure Que workers to parameterise the job acquisition query by
priority threshold, enabling gradual transition from one pool of workers
to another.

This is **never intended to be merged**. We'll rely on this feature branch for the duration of the switchover, but it shouldn't make its way to master.