### PR TITLE
Declare the gem's dependency on ActiveSupport

### DIFF
--- a/que.gemspec
+++ b/que.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.3'
+
+  spec.add_runtime_dependency 'activesupport'
 end


### PR DESCRIPTION
We now [use][1] ActiveSupport in `Que::Job`. This dependency isn't declared in the gemspec, so it can cause projects using Que to blow up (e.g. [que-failure][2]).

This declares the dependency on `activesupport`. I haven't specified a specific version because the method calls I've identified which require `active_support/core_ext` are using sugary `Hash` methods that have been around for a while.

[1]: https://github.com/gocardless/que/blob/master/lib/que/job.rb#L1-L2
[2]: https://circleci.com/gh/gocardless/que-failure/17?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link