### PR TITLE
Prevent logging HashWithIndifferentAccess

### DIFF
--- a/lib/que.rb
+++ b/lib/que.rb
@@ -49,7 +49,7 @@ module Que
 
   class << self
     attr_accessor :error_handler
-    attr_writer :logger, :adapter, :log_formatter, :disable_prepared_statements, :json_converter
+    attr_writer :logger, :adapter, :disable_prepared_statements, :json_converter
 
     def connection=(connection)
       self.adapter =
@@ -110,21 +110,8 @@ module Que
       migrate! :version => 0
     end
 
-    def log(data)
-      level = data.delete(:level) || :info
-      data = {:lib => 'que', :hostname => Socket.gethostname, :pid => Process.pid, :thread => Thread.current.object_id}.merge(data)
-
-      if (l = logger) && output = log_formatter.call(data)
-        l.send level, output
-      end
-    end
-
     def logger
       @logger.respond_to?(:call) ? @logger.call : @logger
-    end
-
-    def log_formatter
-      @log_formatter ||= JSON_MODULE.method(:dump)
     end
 
     def disable_prepared_statements

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -52,7 +52,8 @@ module Que
           # this ID, and succeed, despite the job having already been worked.
           return :job_worked unless job_exists?(job)
 
-          log_keys = job.slice("id", "priority", "args", "queue")
+          # job is a HashWithIndifferentAccess, so .to_h to avoid serialization issues
+          log_keys = job.slice("id", "priority", "args", "queue").to_h
 
           begin
             Que.logger&.info(

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -32,7 +32,7 @@ module Que
         break if @stop
       end
     ensure
-      stop_trace.call
+      stop_trace.call if stop_trace
     end
 
     def work


### PR DESCRIPTION
The job variable is actually a HashWithIndifferentAccess instance, which
screws up any serialization your log formatter might do downstream. to_h
will get us a plain Ruby Hash which will play much better.