### PR TITLE
Que::Locker with performance patch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ end
 group :test do
   gem 'rspec', '~> 2.14.1'
   gem 'pry'
+  gem 'pry-byebug'
 end
 
 platforms :rbx do

--- a/bin/que
+++ b/bin/que
@@ -20,6 +20,10 @@ OptionParser.new do |opts|
     options.metrics_port = metrics_port
   end
 
+  opts.on('-e', '--cursor-expiry [EXPIRY]', Integer, "Enable performance patch with cached cursors") do |cursor_expiry|
+    options.cursor_expiry = cursor_expiry
+  end
+
   opts.on('-m', '--metrics-labels [LABELS]', String, "Base labels for each prometheus metric, in key=value,... form") do |metrics_labels|
     options.metrics_labels = metrics_labels.split(",").each_with_object({}) do |kv, labels|
       key, value = kv.split("=")
@@ -79,11 +83,15 @@ end
 queue_name     = options.queue_name     || ENV['QUE_QUEUE'] || Que::Job::DEFAULT_QUEUE
 wake_interval  = options.wake_interval  || ENV['QUE_WAKE_INTERVAL']&.to_f
 metrics_labels = options.metrics_labels || {}
+cursor_expiry  = options.cursor_expiry  || 0
 
 $stdout.puts 'Starting worker...'
 
-worker = Que::Worker.
-  new(queue: queue_name, wake_interval: wake_interval, metrics_labels: metrics_labels)
+worker = Que::Worker.new(
+  queue: queue_name, wake_interval: wake_interval,
+  lock_cursor_expiry: cursor_expiry,
+  metrics_labels: metrics_labels
+)
 Thread.new { worker.metrics.expose(port: options.metrics_port) } if options.metrics_port
 
 %w[INT TERM].each { |signal| trap(signal) { worker.stop! } }

--- a/lib/que.rb
+++ b/lib/que.rb
@@ -9,6 +9,8 @@ module Que
   autoload :SQL,        'que/sql'
   autoload :Version,    'que/version'
   autoload :Worker,     'que/worker'
+  autoload :Metrics,    'que/metrics'
+  autoload :Locker,     'que/locker'
 
   begin
     require 'multi_json'

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -5,6 +5,7 @@ module Que
   class Job
     # These are order dependent, as we use them in prepared statements
     JOB_OPTIONS = %i[queue priority run_at job_class retryable].freeze
+    JOB_INSTANCE_FIELDS = %i[queue priority run_at job_id].freeze
 
     # These are set in the class definition of the Job, as instance variables on the class
     def self.default_attrs

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Que
+  # The Locker is used to acquire a job from the Postgres jobs table. The only method we
+  # expose is with_locked_job, as we want to ensure that callers safely unlock their jobs.
+  #
+  # For performance, the locker keeps track of the last job ID it locked, and uses that
+  # job's ID to begin the next attempt to acquire a job. There is a point where the
+  # performance of lock acquisition goes off a cliff, and using the previous job's ID
+  # delays the point at which that occurs.
+  #
+  # For more information, see the 'Predicate Specificity' chapter of:
+  # https://brandur.org/postgres-queues
+  class Locker
+    def initialize(queue:, cursor_expiry:, metrics:)
+      @queue = queue
+      @metrics = metrics
+      @cursor_expiry = cursor_expiry
+      @cursor = 0
+      @cursor_expires_at = monotonic_now
+    end
+
+    # Acquire a job for the period of running the given block.
+    def with_locked_job
+      reset_cursor if cursor_expired?
+
+      # Check that the job hasn't just been worked by another worker (it's possible to
+      # lock a job that's just been destroyed because pg locks don't obey MVCC). If it has
+      # been worked, act as if we've worked it.
+      #
+      # This can happen with jobs that are already being worked when we begin our lock
+      # query. The job row exists but is locked at the point that we materialise our job
+      # rows for use in the recursive query. At some point after that, but before we
+      # attempt to take our lock, the original worker destroys the job row and unlocks the
+      # advisory lock. We then attempt to lock the ID, and succeed, despite the job having
+      # already been worked.
+      #
+      # To avoid working the job a second time, we check whether it exists again after
+      # acquiring the lock on it.
+      job = lock_job
+      reset_cursor unless job # if no job was found, we should reset the cursor
+      job = nil unless exists?(job)
+
+      @cursor = job[:job_id] if job
+
+      yield job
+    ensure
+      Que.execute("SELECT pg_advisory_unlock($1)", [job[:job_id]]) if job
+    end
+
+    private
+
+    def lock_job
+      @metrics.trace_acquire_job(queue: @queue) do
+        Que.execute(:lock_job, [@queue, @cursor]).first
+      end
+    end
+
+    def cursor_expired?
+      @cursor_expires_at < monotonic_now
+    end
+
+    def reset_cursor
+      @cursor = 0
+      @cursor_expires_at = monotonic_now + @cursor_expiry
+    end
+
+    def exists?(job)
+      Que.execute(:check_job, job.values_at(*Job::JOB_INSTANCE_FIELDS)).any? if job
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -51,6 +51,7 @@ module Que
           SELECT j
           FROM que_jobs AS j
           WHERE queue = $1::text
+          AND job_id >= $2
           AND run_at <= now()
           AND retryable = true
           ORDER BY priority, run_at, job_id

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -2,19 +2,26 @@
 
 require "benchmark"
 require "que/metrics"
+require "que/locker"
 
 module Que
   class Worker
     # Defines the time a worker will wait before checking Postgres for its next job
-    WAKE_INTERVAL = 5
     DEFAULT_QUEUE = ''
-    JOB_INSTANCE_FIELDS = %i[queue priority run_at job_id].freeze
+    DEFAULT_WAKE_INTERVAL = 5
+    DEFAULT_LOCK_CURSOR_EXPIRY = 0 # seconds
 
-    def initialize(queue: DEFAULT_QUEUE, wake_interval: WAKE_INTERVAL, metrics_labels: {})
-      @queue  = queue
+    def initialize(
+      queue: DEFAULT_QUEUE,
+      wake_interval: DEFAULT_WAKE_INTERVAL,
+      lock_cursor_expiry: DEFAULT_LOCK_CURSOR_EXPIRY,
+      metrics_labels: {}
+    )
+      @queue = queue
       @wake_interval = wake_interval
-      @stop = false
       @metrics = Metrics.new(labels: metrics_labels)
+      @locker = Locker.new(queue: queue, cursor_expiry: lock_cursor_expiry, metrics: metrics)
+      @stop = false
     end
 
     attr_reader :metrics
@@ -37,20 +44,8 @@ module Que
 
     def work
       Que.adapter.checkout do
-        with_locked_job do |job|
+        @locker.with_locked_job do |job|
           return :job_not_found if job.nil?
-
-          # Check that the job hasn't just been worked by another worker (it's possible to
-          # lock a job that's just been destroyed because pg locks don't obey MVCC). If it
-          # has been worked, act as if we've worked it.
-          #
-          # In explanation, what happens to cause this is a job is already being processed
-          # when we begin our lock query. This means the job row exists but is locked when
-          # we have materialized our job rows for use in the recursive query. At some
-          # point after this, but before we attempt to take our lock, the original worker
-          # destroys the job row and unlocks the advisory lock. We then attempt to lock
-          # this ID, and succeed, despite the job having already been worked.
-          return :job_worked unless job_exists?(job)
 
           log_keys = {
             id: job["job_id"],
@@ -122,25 +117,9 @@ module Que
           count,
           count ** 4 + 3, # exponentially back off when retrying failures
           "#{error.message}\n#{error.backtrace.join("\n")}",
-          *job.values_at(*JOB_INSTANCE_FIELDS)
+          *job.values_at(*Job::JOB_INSTANCE_FIELDS)
         ]
       )
-    end
-
-    def with_locked_job
-      # Separate the job acquisition from yielding the job, as we want to track the job
-      # runtime separately.
-      job = @metrics.trace_acquire_job(queue: @queue) do
-        Que.execute(:lock_job, [@queue]).first
-      end
-
-      yield job
-    ensure
-      Que.execute("SELECT pg_advisory_unlock($1)", [job[:job_id]]) if job
-    end
-
-    def job_exists?(job)
-      Que.execute(:check_job, job.values_at(*JOB_INSTANCE_FIELDS)).any?
     end
 
     def class_for(string)

--- a/spec/lib/que/locker_spec.rb
+++ b/spec/lib/que/locker_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Que::Locker do
+  subject(:locker) do
+    described_class.new(
+      queue: queue,
+      cursor_expiry: cursor_expiry,
+      metrics: Que::Metrics.new,
+    )
+  end
+
+  let(:queue) { "default" }
+  let(:cursor_expiry) { 0 }
+
+  describe ".with_locked_job" do
+    before { allow(Que).to receive(:execute).and_call_original }
+
+    # Helper to call the with_locked_job method but ensure our block has actually been
+    # called. Without this, it's possible that we'd never run expectations in our block.
+    def with_locked_job(&block)
+      block_called = false
+      locker.with_locked_job do |job|
+        block.call(job)
+        block_called = true
+      end
+
+      raise "did not call job block" unless block_called
+    end
+
+    # Simulates actual working of a job, which is useful to these tests to free up another
+    # job for locking.
+    def expect_to_work(job)
+      with_locked_job do |actual_job|
+        expect(actual_job[:job_id]).to eql(job[:job_id])
+        expect(Que).to receive(:execute).
+          with("SELECT pg_advisory_unlock($1)", [job[:job_id]])
+
+        # Destroy the job to simulate the behaviour of the queue, and allow our lock query
+        # to discover new jobs.
+        QueJob.find(job[:job_id]).destroy!
+      end
+    end
+
+    # Our tests are very concerned with which cursor we use and when
+    def expect_to_lock_with(cursor:)
+      expect(Que).to receive(:execute).with(:lock_job, [queue, cursor])
+    end
+
+    context "with no jobs to lock" do
+      it "scans entire table and calls block with nil job" do
+        expect(Que).to receive(:execute).with(:lock_job, [queue, 0])
+
+        with_locked_job do |job|
+          expect(job).to be_nil
+        end
+      end
+    end
+
+    context "with just one job to lock" do
+      let!(:job_1) { FakeJob.enqueue(1, queue: queue, priority: 1).attrs }
+      let(:cursor_expiry) { 60 }
+
+      # Pretend time isn't moving, as we don't want to test cursor expiry here
+      before { allow(Process).to receive(:clock_gettime).and_return(0) }
+
+      # We want our workers to start from the front of the queue immediately after finding
+      # no jobs are available to work.
+      it "will use a cursor until no jobs are found" do
+        expect_to_lock_with(cursor: 0)
+        expect_to_work(job_1)
+
+        expect_to_lock_with(cursor: job_1[:job_id])
+        with_locked_job { }
+
+        expect_to_lock_with(cursor: 0)
+        with_locked_job { }
+      end
+    end
+
+    context "with jobs to lock" do
+      let!(:job_1) { FakeJob.enqueue(1, queue: queue, priority: 1).attrs }
+      let!(:job_2) { FakeJob.enqueue(2, queue: queue, priority: 2).attrs }
+      let!(:job_3) { FakeJob.enqueue(3, queue: queue, priority: 3).attrs }
+
+      it "locks and then unlocks the most important job" do
+        expect_to_lock_with(cursor: 0)
+        expect_to_work(job_1)
+      end
+
+      context "on subsequent locks" do
+        context "with non-zero cursor expiry" do
+          let(:cursor_expiry) { 5 }
+
+          before do
+            allow(locker).to receive(:monotonic_now) do
+              @epoch
+            end
+          end
+
+          # This test simulates the repeated locking of jobs. We're trying to prove that
+          # the locker will use the previous jobs ID as a cursor until the expiry has
+          # elapsed, after which we'll reset.
+          #
+          # We do this by expecting on the calls to lock_job, specifically the second
+          # parameter which controls the job_id cursor value.
+          it "continues lock from previous job id, until cursor expires" do
+            @epoch = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            expect_to_lock_with(cursor: 0)
+            expect_to_work(job_1)
+
+            @epoch += 2
+            expect_to_lock_with(cursor: job_1[:job_id])
+            expect_to_work(job_2)
+
+            @epoch += cursor_expiry # our cursor should now expire
+            expect_to_lock_with(cursor: 0)
+            expect_to_work(job_3)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/que/worker_spec.rb
+++ b/spec/lib/que/worker_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Que::Worker do
         it "rescues it and returns an error" do
           FakeJob.enqueue(1)
 
-          expect(Que).to receive(:execute).with(:lock_job, [""]).and_raise(PG::Error)
+          expect(Que).to receive(:execute).with(:lock_job, ["", 0]).and_raise(PG::Error)
           expect(subject).to eq(:error)
         end
       end


### PR DESCRIPTION
https://brandur.org/postgres-queues

Extract locking into a separate object which tracks the last locked job
ID as a cursor for subsequent locking queries. This adaption pushes back
the point at which high dead tuple counts in the que_jobs table will
affect the lock query.