### PR TITLE
Add a timeout to the worker shutdown procedure

### DIFF
--- a/bin/que
+++ b/bin/que
@@ -5,6 +5,8 @@ require 'optparse'
 require 'ostruct'
 require 'logger'
 
+class QueJobTimeoutError < StandardError; end
+
 $stdout.sync = true
 
 options = OpenStruct.new
@@ -37,6 +39,14 @@ OptionParser.new do |opts|
 
   opts.on('-q', '--queue-name [NAME]', String, "Set the name of the queue to work jobs from (default: the default queue)") do |queue_name|
     options.queue_name = queue_name
+  end
+
+  opts.on('--timeout [TIMEOUT]', Integer, "Set the amount of time (in seconds) to wait, after receiving SIGTERM/SIGINT, for a worker to finish before forcing it to stop") do |timeout|
+    options.timeout = timeout
+  end
+
+  opts.on('--timeout-message [MESSAGE]', String, "Set the exception message that will be sent in the event of a worker timeout") do |timeout_message|
+    options.timeout_message = timeout_message
   end
 
   opts.on('-v', '--version', "Show Que version") do
@@ -80,22 +90,47 @@ rescue NameError
   exit 1
 end
 
-queue_name     = options.queue_name     || ENV['QUE_QUEUE'] || Que::Worker::DEFAULT_QUEUE
-wake_interval  = options.wake_interval  || ENV['QUE_WAKE_INTERVAL']&.to_f
-metrics_labels = options.metrics_labels || {}
-cursor_expiry  = options.cursor_expiry  || 0
+queue_name          = options.queue_name         || ENV['QUE_QUEUE'] || Que::Worker::DEFAULT_QUEUE
+wake_interval       = options.wake_interval      || ENV['QUE_WAKE_INTERVAL']&.to_f
+metrics_labels      = options.metrics_labels     || {}
+cursor_expiry       = options.cursor_expiry      || 0
+timeout             = options.timeout            || 0
+timeout_message     = options.timeout_message    || ""
 
 Que.logger.info(msg: 'Starting worker', event: 'que.worker.start')
 
 worker = Que::Worker.new(
-  queue: queue_name, wake_interval: wake_interval,
+  queue: queue_name,
+  wake_interval: wake_interval,
   lock_cursor_expiry: cursor_expiry,
-  metrics_labels: metrics_labels
+  metrics_labels: metrics_labels,
+  priority_threshold: priority_threshold
 )
+
 Thread.new { worker.metrics.expose(port: options.metrics_port) } if options.metrics_port
 
-%w[INT TERM].each { |signal| trap(signal) { worker.stop! } }
+stop = false
+%w[INT TERM].each { |signal| trap(signal) { stop = true } }
 
-worker.work_loop
+worker_thread = Thread.new { worker.work_loop }
 
-Que.logger.info(msg: 'Finished work, exiting', event: 'que.worker.finish')
+loop { sleep 0.1 until stop }
+
+Que.logger.info(msg: 'Waiting for worker to finish', event: 'que.worker.finish_wait')
+
+worker.stop!
+
+if timeout
+  timeout.seconds.downto(0) do
+    break unless worker_thread.alive?
+    sleep 1
+  end
+
+  if worker_thread.alive?
+    Que.logger.info(msg: 'Worker still running - forcing it to stop', event: 'que.worker.finish_force')
+    worker_thread.raise(QueJobTimeoutError, timeout_message)
+    worker_thread.join
+  end
+end
+
+Que.logger.info(msg: 'Worker finished, exiting', event: 'que.worker.finish')

--- a/docs/shutting_down_safely.md
+++ b/docs/shutting_down_safely.md
@@ -5,3 +5,25 @@ To ensure safe operation, Que needs to be very careful in how it shuts down. Whe
 To prevent this, Que will block a Ruby process from exiting until all jobs it is working have completed normally. Unfortunately, if you have long-running jobs, this may take a very long time (and if something goes wrong with a job's logic, it may never happen). The solution in this case is SIGKILL - luckily, Ruby processes that are killed via SIGKILL will end without using Thread#kill on its running threads. This is safer than exiting normally - when PostgreSQL loses the connection it will simply roll back the open transaction, if any, and unlock the job so it can be retried later by another worker. Be sure to read [Writing Reliable Jobs](https://github.com/chanks/que/blob/master/docs/writing_reliable_jobs.md) for information on how to design your jobs to fail safely.
 
 So, be prepared to use SIGKILL on your Ruby processes if they run for too long. For example, Heroku takes a good approach to this - when Heroku's platform is shutting down a process, it sends SIGTERM, waits ten seconds, then sends SIGKILL if the process still hasn't exited. This is a nice compromise - it will give each of your currently running jobs ten seconds to complete, and any jobs that haven't finished by then will be interrupted and retried later.
+
+## SIGKILL and `NoRetry`
+
+If you're using the `NoRetry` strategy from
+[`que-failure`](https://github.com/gocardless/que-failure), allowing your
+workers to be SIGKILLed can cause jobs that were being worked at the time to
+enter an interstitial state where they aren't marked as failed but will not be
+picked up by future workers. This is because the strategy marks the job at the
+start, when the worker picks it up, and at the end. Because SIGKILL immediately
+stops the process, the strategy cannot update the job to indicate failure.
+
+To get around this, Que supports setting a worker timeout, which is an amount of
+time that it will wait, after receiving a SIGTERM or SIGINT, for a worker to
+stop. If the worker has not stopped within that time, Que will raise a
+`QueJobTimeoutError` exception, which will be handled by the `NoRetry` strategy
+failure handler and ensure that the job is properly marked as failed.
+
+The timeout can be specified in an argument to the `que` executable, as well as
+a message to send with the exception. Run `bin/que --help` for more information.
+We recommend setting the timeout to a value slightly less than the time between
+SIGTERM and SIGKILL in your environment (e.g. on Heroku, this would be 8-9
+seconds).


### PR DESCRIPTION
This allows us to deal with the situation where a job using the
`NoRetry` strategy takes a long time to complete. Normally this would
result in the process being forcibly killed (SIGKILL) by our scheduler. By
setting this timeout to just under the time between SIGTERM and SIGKILL, we
can ensure that the job fails cleanly, with a clear error message.

Only the last commit needs review, of course. The rest is rebased off our existing priority threshold branch.