### PR TITLE
Work logging tweaks

### DIFF
--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -62,7 +62,7 @@ module Que
           begin
             Que.logger&.info(
               log_keys.merge(
-                event: "job_begin",
+                event: "que_job.job_begin",
                 msg: "Job acquired, beginning work",
               )
             )
@@ -75,7 +75,7 @@ module Que
 
             Que.logger&.info(
               log_keys.merge(
-                event: "job_worked",
+                event: "que_job.job_worked",
                 msg: "Successfully worked job",
                 duration: duration,
               )
@@ -83,7 +83,7 @@ module Que
           rescue => error
             Que.logger&.error(
               log_keys.merge(
-                event: "job_error",
+                event: "que_job.job_error",
                 msg: "Job failed with error",
                 error: error.to_s,
               )

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -54,6 +54,7 @@ module Que
             id: job["job_id"],
             priority: job["priority"],
             queue: job["queue"],
+            handler: job["job_class"],
             job_class: job["job_class"],
             job_error_count: job["error_count"],
           }

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -51,12 +51,12 @@ module Que
           return :job_not_found if job.nil?
 
           log_keys = {
-            id: job["job_id"],
             priority: job["priority"],
             queue: job["queue"],
             handler: job["job_class"],
             job_class: job["job_class"],
             job_error_count: job["error_count"],
+            que_job_id: job["job_id"],
           }
 
           begin

--- a/spec/lib/que/worker_spec.rb
+++ b/spec/lib/que/worker_spec.rb
@@ -23,26 +23,26 @@ RSpec.describe Que::Worker do
         expect(Que.logger).to receive(:info).
           with(hash_including({
             event: "que_job.job_begin",
-            id: job.attrs["job_id"],
             handler: "FakeJob",
             job_class: "FakeJob",
             job_error_count: 0,
             msg: "Job acquired, beginning work",
             priority: 100,
             queue: "",
+            que_job_id: job.attrs["job_id"],
           }))
 
         expect(Que.logger).to receive(:info).
           with(hash_including({
             duration: kind_of(Float),
             event: "que_job.job_worked",
-            id: job.attrs["job_id"],
             handler: "FakeJob",
             job_class: "FakeJob",
             job_error_count: 0,
             msg: "Successfully worked job",
             priority: 100,
             queue: "",
+            que_job_id: job.attrs["job_id"],
           }))
 
         subject

--- a/spec/lib/que/worker_spec.rb
+++ b/spec/lib/que/worker_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Que::Worker do
       it "logs the work" do
         expect(Que.logger).to receive(:info).
           with(hash_including({
-            event: "job_begin",
+            event: "que_job.job_begin",
             id: job.attrs["job_id"],
             handler: "FakeJob",
             job_class: "FakeJob",
@@ -35,7 +35,7 @@ RSpec.describe Que::Worker do
         expect(Que.logger).to receive(:info).
           with(hash_including({
             duration: kind_of(Float),
-            event: "job_worked",
+            event: "que_job.job_worked",
             id: job.attrs["job_id"],
             handler: "FakeJob",
             job_class: "FakeJob",
@@ -61,7 +61,7 @@ RSpec.describe Que::Worker do
 
         expect(Que.logger).to receive(:info).
           with(hash_including({
-            event: "job_begin",
+            event: "que_job.job_begin",
             handler: "ExceptionalJob",
             job_class: "ExceptionalJob",
             msg: "Job acquired, beginning work",
@@ -69,7 +69,7 @@ RSpec.describe Que::Worker do
 
         expect(Que.logger).to receive(:error).
           with(hash_including({
-            event: "job_error",
+            event: "que_job.job_error",
             handler: "ExceptionalJob",
             job_class: "ExceptionalJob",
             msg: "Job failed with error",

--- a/spec/lib/que/worker_spec.rb
+++ b/spec/lib/que/worker_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Que::Worker do
           with(hash_including({
             event: "job_begin",
             id: job.attrs["job_id"],
+            handler: "FakeJob",
             job_class: "FakeJob",
             job_error_count: 0,
             msg: "Job acquired, beginning work",
@@ -36,6 +37,7 @@ RSpec.describe Que::Worker do
             duration: kind_of(Float),
             event: "job_worked",
             id: job.attrs["job_id"],
+            handler: "FakeJob",
             job_class: "FakeJob",
             job_error_count: 0,
             msg: "Successfully worked job",
@@ -60,6 +62,7 @@ RSpec.describe Que::Worker do
         expect(Que.logger).to receive(:info).
           with(hash_including({
             event: "job_begin",
+            handler: "ExceptionalJob",
             job_class: "ExceptionalJob",
             msg: "Job acquired, beginning work",
           }))
@@ -67,6 +70,7 @@ RSpec.describe Que::Worker do
         expect(Que.logger).to receive(:error).
           with(hash_including({
             event: "job_error",
+            handler: "ExceptionalJob",
             job_class: "ExceptionalJob",
             msg: "Job failed with error",
           }))


### PR DESCRIPTION
This brings the log format in line with some of our conventions:
- Adds `handler` property to job work logs
- Adds `que_job.` prefix to job work logs (Que-related logs already have the `que.` prefix, e.g. [here](https://github.com/gocardless/que/blob/d4cc2748b4b5685426f94e48eb1296ee1f7d8b4a/lib/que/worker.rb#L36))
- Renames `id` to `que_job_id`

DET-78