### PR TITLE
Threaded workers (--worker-count)

### DIFF
--- a/benchmark/setup.rb
+++ b/benchmark/setup.rb
@@ -7,7 +7,8 @@ Que.connection = ActiveRecord
 
 Que.logger = Logger.new(STDOUT)
 Que.logger.formatter = proc do |severity, datetime, progname, payload|
-  { ts: datetime, level: severity }.merge(payload).to_json + "\n"
+  { ts: datetime, tid: Thread.current.object_id, level: severity }.
+    merge(payload).to_json + "\n"
 end
 
 class QueJob < ActiveRecord::Base

--- a/benchmark/start-worker
+++ b/benchmark/start-worker
@@ -3,6 +3,7 @@
 bundle exec que \
   --metrics-labels "host=${HOSTNAME},env=benchmark" \
   --metrics-port 8080 \
+  --worker-count "${WORKER_COUNT}" \
   --wake-interval "${WAKE_INTERVAL}" \
   --cursor-expiry "${CURSOR_EXPIRY}" \
   --log-level INFO \

--- a/bin/que
+++ b/bin/que
@@ -5,8 +5,6 @@ require 'optparse'
 require 'ostruct'
 require 'logger'
 
-class QueJobTimeoutError < StandardError; end
-
 $stdout.sync = true
 
 options = OpenStruct.new
@@ -26,6 +24,10 @@ OptionParser.new do |opts|
     options.cursor_expiry = cursor_expiry
   end
 
+  opts.on('-c', '--worker-count [COUNT]', Integer, "Start this many threaded workers") do |worker_count|
+    options.worker_count = worker_count
+  end
+
   opts.on('-m', '--metrics-labels [LABELS]', String, "Base labels for each prometheus metric, in key=value,... form") do |metrics_labels|
     options.metrics_labels = metrics_labels.split(",").each_with_object({}) do |kv, labels|
       key, value = kv.split("=")
@@ -41,12 +43,8 @@ OptionParser.new do |opts|
     options.queue_name = queue_name
   end
 
-  opts.on('--timeout [TIMEOUT]', Integer, "Set the amount of time (in seconds) to wait, after receiving SIGTERM/SIGINT, for a worker to finish before forcing it to stop") do |timeout|
+  opts.on('--timeout [TIMEOUT]', Integer, "Set the amount of time (in seconds) to wait, after receiving SIGTERM/SIGINT, for workers to finish before forcing them to stop") do |timeout|
     options.timeout = timeout
-  end
-
-  opts.on('--timeout-message [MESSAGE]', String, "Set the exception message that will be sent in the event of a worker timeout") do |timeout_message|
-    options.timeout_message = timeout_message
   end
 
   opts.on('-v', '--version', "Show Que version") do
@@ -90,46 +88,34 @@ rescue NameError
   exit 1
 end
 
-queue_name          = options.queue_name         || ENV['QUE_QUEUE'] || Que::Worker::DEFAULT_QUEUE
-wake_interval       = options.wake_interval      || ENV['QUE_WAKE_INTERVAL']&.to_f
-metrics_labels      = options.metrics_labels     || {}
-cursor_expiry       = options.cursor_expiry      || 0
-timeout             = options.timeout
-timeout_message     = options.timeout_message    || ""
+def wait_for_signals(*signals, sleep_interval: 1)
+  received_signal = false
+  signals.each { |signal| trap(signal) { received_signal = true } }
 
-Que.logger.info(msg: 'Starting worker', event: 'que.worker.start')
+  sleep(sleep_interval) until received_signal
+end
 
-worker = Que::Worker.new(
+queue_name     = options.queue_name     || ENV['QUE_QUEUE'] || Que::Worker::DEFAULT_QUEUE
+wake_interval  = options.wake_interval  || ENV['QUE_WAKE_INTERVAL']&.to_f
+metrics_labels = options.metrics_labels || {}
+cursor_expiry  = options.cursor_expiry  || 0
+worker_count   = options.worker_count   || 1
+timeout        = options.timeout
+
+stop_workers = Que::Worker.start_workers(
+  worker_count,
   queue: queue_name,
   wake_interval: wake_interval,
   lock_cursor_expiry: cursor_expiry,
-  metrics_labels: metrics_labels
+  metrics_labels: metrics_labels,
+  metrics_registry: Prometheus::Client.registry
 )
 
-Thread.new { worker.metrics.expose(port: options.metrics_port) } if options.metrics_port
-
-stop = false
-%w[INT TERM].each { |signal| trap(signal) { stop = true } }
-
-worker_thread = Thread.new { worker.work_loop }
-
-sleep 0.1 until stop
-
-Que.logger.info(msg: 'Waiting for worker to finish', event: 'que.worker.finish_wait')
-
-worker.stop!
-
-if timeout
-  timeout.seconds.downto(0) do
-    break unless worker_thread.alive?
-    sleep 1
-  end
-
-  if worker_thread.alive?
-    Que.logger.info(msg: 'Worker still running - forcing it to stop', event: 'que.worker.finish_force')
-    worker_thread.raise(QueJobTimeoutError, timeout_message)
-    worker_thread.join
+if options.metrics_port
+  Thread.new do
+    Que::Metrics.expose(Prometheus::Client.registry, port: options.metrics_port)
   end
 end
 
-Que.logger.info(msg: 'Worker finished, exiting', event: 'que.worker.finish')
+wait_for_signals("INT", "TERM")
+stop_workers.call(timeout)

--- a/docs/shutting_down_safely.md
+++ b/docs/shutting_down_safely.md
@@ -19,8 +19,8 @@ stops the process, the strategy cannot update the job to indicate failure.
 To get around this, Que supports setting a worker timeout, which is an amount of
 time that it will wait, after receiving a SIGTERM or SIGINT, for a worker to
 stop. If the worker has not stopped within that time, Que will raise a
-`QueJobTimeoutError` exception, which will be handled by the `NoRetry` strategy
-failure handler and ensure that the job is properly marked as failed.
+`Que::JobTimeoutError` exception, which will be handled by the `NoRetry`
+strategy failure handler and ensure that the job is properly marked as failed.
 
 The timeout can be specified in an argument to the `que` executable, as well as
 a message to send with the exception. Run `bin/que --help` for more information.

--- a/spec/helpers/sleep_job.rb
+++ b/spec/helpers/sleep_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SleepJob < Que::Job
+  def run(duration)
+    sleep(duration)
+  end
+end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -1,18 +1,11 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "que/worker" # required to prevent autoload races
 
 RSpec.describe "multiple workers" do
-  def with_workers(n)
-    workers = Array.new(n) { Que::Worker.new(wake_interval: 0.1) }
-    worker_threads = workers.map { |worker| Thread.new { worker.work_loop } }
-
-    yield
-
-    workers.each(&:stop!)
-    worker_threads.each do |thread|
-      raise "timed out waiting for worker to finish!" unless thread.join(5)
-    end
+  def with_workers(n, stop_timeout: 5)
+    Que::Worker.start_workers(n, wake_interval: 0.01).tap { yield }.call(stop_timeout)
   end
 
   # Wait for a maximum of [timeout] seconds for all jobs to be worked
@@ -70,6 +63,22 @@ RSpec.describe "multiple workers" do
       expect(QueJob.count).to eq(0)
       expect(User.count).to eq(3)
       expect(User.all.map(&:name).sort).to eq(["alice", "bob", "charlie"])
+    end
+  end
+
+  context "with jobs that exceed stop timeout" do
+    it "raises Que::JobTimeoutError" do
+      SleepJob.enqueue(5) # sleep 5s
+
+      # Sleep to let the worker pick-up the SleepJob, then stop the worker with an
+      # aggressive timeout. This should cause JobTimeout to be raised in the worker
+      # thread.
+      with_workers(1, stop_timeout: 0.01) { sleep 0.1 }
+
+      sleep_job = QueJob.last
+
+      expect(sleep_job).not_to be(nil)
+      expect(sleep_job.last_error).to match(/Job exceeded timeout when requested to stop/)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,12 @@ require 'que'
 require 'rspec'
 require 'active_record'
 
-require_relative "./helpers/que_job"
-require_relative "./helpers/fake_job"
-require_relative "./helpers/exceptional_job"
-require_relative "./helpers/user"
 require_relative "./helpers/create_user"
+require_relative "./helpers/exceptional_job"
+require_relative "./helpers/fake_job"
+require_relative "./helpers/que_job"
+require_relative "./helpers/sleep_job"
+require_relative "./helpers/user"
 
 def postgres_now
   now = ActiveRecord::Base.connection.execute("SELECT NOW();")[0]["now"]
@@ -40,5 +41,11 @@ RSpec.configure do |config|
     FakeJob.log = []
     ExceptionalJob.log = []
     ExceptionalJob::WithFailureHandler.log = []
+
+    # In normal runtime we'll new-up metrics with consistent labels, but in tests we'll
+    # create workers with all sorts of configurations. Ensure we clear the registry to
+    # prevent mis-matched metric labels from raising exceptions from the incompatible
+    # configurations.
+    Prometheus::Client.registry.instance_eval { @metrics.clear }
   end
 end


### PR DESCRIPTION
Allow creation of a threaded Que worker pool. This used to be in Que,
but was removed during a tidy-up.

The new threaded pool incorporates the work done on stop timeouts to
ensure we mark Que jobs as having failed, with the associated exception,
if the worker is requested to stop but fails to do so in time.

Notable changes include the removal of the --timeout-message flag (given
this can be provided by the Que::JobTimeoutError exception) and the
namespacing of the JobTimeoutError under the Que module. This will
require a small change in QueFailure.