### PR TITLE
Bump to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 1.0.0 (2018-07-20)
+
+*   Refactor of Que internals
+*   Prometheus metrics
+*   Changes to logging key/values
+*   Introduction of Kubernetes benchmark code
+*   Performance patch to Que locking
+
 ### 0.11.8 (2017-07-12)
 
 *   Serialise and deserialise job args when running in sync mode. (georgea93)

--- a/lib/que/version.rb
+++ b/lib/que/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Que
-  Version = '0.11.8'
+  Version = '1.0.0'
 end


### PR DESCRIPTION
We've made several large changes to Que recently, some of which are
breaking. We should bump to a new major version so that dependent gems
like que-failure can specify which version they lock against.