### PR TITLE
Enable autoloading of Que::JobTimeoutError

### DIFF
--- a/lib/que.rb
+++ b/lib/que.rb
@@ -3,14 +3,15 @@
 require 'socket' # For hostname
 
 module Que
-  autoload :Adapters,   'que/adapters/base'
-  autoload :Job,        'que/job'
-  autoload :Migrations, 'que/migrations'
-  autoload :SQL,        'que/sql'
-  autoload :Version,    'que/version'
-  autoload :Worker,     'que/worker'
-  autoload :Metrics,    'que/metrics'
-  autoload :Locker,     'que/locker'
+  autoload :Adapters,        'que/adapters/base'
+  autoload :Job,             'que/job'
+  autoload :Migrations,      'que/migrations'
+  autoload :SQL,             'que/sql'
+  autoload :Version,         'que/version'
+  autoload :Worker,          'que/worker'
+  autoload :Metrics,         'que/metrics'
+  autoload :Locker,          'que/locker'
+  autoload :JobTimeoutError, 'que/job_timeout_error'
 
   begin
     require 'multi_json'

--- a/lib/que/job_timeout_error.rb
+++ b/lib/que/job_timeout_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Que
+  class JobTimeoutError < StandardError; end
+end

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -3,10 +3,9 @@
 require "benchmark"
 require "que/metrics"
 require "que/locker"
+require "que/job_timeout_error"
 
 module Que
-  class JobTimeoutError < StandardError; end
-
   class Worker
     # Defines the time a worker will wait before checking Postgres for its next job
     DEFAULT_QUEUE = ''


### PR DESCRIPTION
**Why?**

We've found this alarming pattern all over the worker codebase: https://github.com/gocardless/payments-service/blob/master/app/workers/mark_credits_as_paid.rb#L69

This outcome of this is we're absorbing `Que::JobTimeoutError` and the job is managing to finish "successfully" as a result, meaning it's not automatically retried. It's not practical to require on FR intervention for every individual instance of this.

As a result, we're going to need to add a varying amount of `raise if error.is_a?(Que::JobTimeoutError)` into examples like the above so we force the job to fail so it can be retried properly. PR here for that: https://github.com/gocardless/payments-service/pull/15881

In the long run, we're going to want to clean up this "rescue everything" pattern. However, with a few hard-to-modify-quickly instances of this problem and a desire to get one variant of a fix in quickly, this is there until we can figure out (correctly) job-by-job what the right exception(s) to catch should be.

I am open to other ways of fixing this issue. We could hack Que to make this work (e.g. base the `JobTimeoutError` from `Exception` rather than `StandardError` but I'm not totally convinced Que is the right place to fix this).