### PR TITLE
Label default queue as 'default' not ''

### DIFF
--- a/lib/que/middleware/queue_collector.rb
+++ b/lib/que/middleware/queue_collector.rb
@@ -13,7 +13,8 @@ module Que
       )
 
       QUEUE_VIEW_SQL = <<~SQL.freeze
-        select queue, job_class, priority
+        select job_class, priority
+             , (case when (queue = '') then 'default' else queue end) as queue
              , (case when (retryable AND run_at < now()) then 'true' else 'false' end) as due
              , count(*)
           from que_jobs

--- a/spec/lib/que/middleware/queue_collector_spec.rb
+++ b/spec/lib/que/middleware/queue_collector_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe Que::Middleware::QueueCollector do
       collector.call({})
 
       expect(described_class::Queued.values).to eql(
-        {queue: "", job_class: "FakeJob", priority: 1, due: "true"} => 2.0,
-        {queue: "", job_class: "FakeJob", priority: 10, due: "true"} => 1.0,
-        {queue: "", job_class: "FakeJob", priority: 1, due: "false"} => 2.0,
+        {queue: "default", job_class: "FakeJob", priority: 1, due: "true"} => 2.0,
+        {queue: "default", job_class: "FakeJob", priority: 10, due: "true"} => 1.0,
+        {queue: "default", job_class: "FakeJob", priority: 1, due: "false"} => 2.0,
         {queue: "another", job_class: "FakeJob", priority: 1, due: "false"} => 1.0,
       )
     end


### PR DESCRIPTION
Que makes a strange decision to use an empty string to represent the
default queue. This is never what people expect, and we should transform
our metric queue label to be 'default' instead of ''.