### PR TITLE
Use 'default' for default queue, instead of ''

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
 *   JobTimeoutError < Interrupt, to avoid accidental rescuing
+*   Change default queue from '' to 'default'
 
 ### 1.0.0 (2018-07-20)
 

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -108,7 +108,7 @@ module Que
       INSERT INTO que_jobs
       (queue, priority, run_at, job_class, retryable, args)
       VALUES
-      (coalesce($1, '')::text, coalesce($2, 100)::smallint, coalesce($3, now())::timestamptz, $4::text, $5::bool, coalesce($6, '[]')::json)
+      (coalesce($1, 'default')::text, coalesce($2, 100)::smallint, coalesce($3, now())::timestamptz, $4::text, $5::bool, coalesce($6, '[]')::json)
       RETURNING *
     }.freeze,
 

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -10,7 +10,7 @@ require_relative "job_timeout_error"
 module Que
   class Worker
     # Defines the time a worker will wait before checking Postgres for its next job
-    DEFAULT_QUEUE = ""
+    DEFAULT_QUEUE = "default"
     DEFAULT_WAKE_INTERVAL = 5
     DEFAULT_LOCK_CURSOR_EXPIRY = 0 # seconds
 

--- a/spec/lib/que/middleware/queue_collector_spec.rb
+++ b/spec/lib/que/middleware/queue_collector_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe Que::Middleware::QueueCollector do
       collector.call({})
 
       expect(described_class::Queued.values).to eql(
-        {queue: "", job_class: "FakeJob", priority: 1, due: "true"} => 2.0,
-        {queue: "", job_class: "FakeJob", priority: 10, due: "true"} => 1.0,
-        {queue: "", job_class: "FakeJob", priority: 1, due: "false"} => 2.0,
+        {queue: "default", job_class: "FakeJob", priority: 1, due: "true"} => 2.0,
+        {queue: "default", job_class: "FakeJob", priority: 10, due: "true"} => 1.0,
+        {queue: "default", job_class: "FakeJob", priority: 1, due: "false"} => 2.0,
         {queue: "another", job_class: "FakeJob", priority: 1, due: "false"} => 1.0,
       )
     end

--- a/spec/lib/que/worker_spec.rb
+++ b/spec/lib/que/worker_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Que::Worker do
             job_error_count: 0,
             msg: "Job acquired, beginning work",
             priority: 100,
-            queue: "",
+            queue: "default",
             que_job_id: job.attrs["job_id"],
           }))
 
@@ -41,7 +41,7 @@ RSpec.describe Que::Worker do
             job_error_count: 0,
             msg: "Successfully worked job",
             priority: 100,
-            queue: "",
+            queue: "default",
             que_job_id: job.attrs["job_id"],
           }))
 
@@ -117,7 +117,7 @@ RSpec.describe Que::Worker do
         it "rescues it and returns an error" do
           FakeJob.enqueue(1)
 
-          expect(Que).to receive(:execute).with(:lock_job, ["", 0]).and_raise(PG::Error)
+          expect(Que).to receive(:execute).with(:lock_job, ["default", 0]).and_raise(PG::Error)
           expect(subject).to eq(:postgres_error)
         end
       end


### PR DESCRIPTION
Que has historically used the empty string '' to represent the default
queue. This causes significant confusion, whereas using the explicit
'default' string would be obvious and clear for anyone who happened to
look.

This commit modifies the default queue value to be 'default'. We do not
include a database migration as this is probably best to do by hand,
updating any jobs that remain in the old '' queue to be 'default' during
the switchover.