### PR TITLE
Log more information from job exceptions

### DIFF
--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -190,7 +190,7 @@ module Que
               log_keys.merge(
                 event: "que_job.job_error",
                 msg: "Job failed with error",
-                error: error.to_s,
+                error: error.inspect,
               )
             )
 

--- a/spec/lib/que/worker_spec.rb
+++ b/spec/lib/que/worker_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe Que::Worker do
             handler: "ExceptionalJob",
             job_class: "ExceptionalJob",
             msg: "Job failed with error",
+            error: "#<ExceptionalJob::Error: bad argument 1>",
           }))
 
         subject


### PR DESCRIPTION
When a job raises an error, we now log the result of error.inspect,
instead of error.to_s. This preserves the class of the message, making
searching for log lines that match certain errors easier.

Relevant to https://gocardless.myjetbrains.com/youtrack/issue/PT-2034.