### PR TITLE
Expose que_dead_tuples metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 *   JobTimeoutError < Interrupt, to avoid accidental rescuing
 *   Change default queue from '' to 'default'
+*   Expose `que_dead_tuples` metric
 
 ### 1.0.0 (2018-07-20)
 

--- a/spec/lib/que/middleware/queue_collector_spec.rb
+++ b/spec/lib/que/middleware/queue_collector_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe Que::Middleware::QueueCollector do
         {queue: "default", job_class: "FakeJob", priority: 1, due: "false"} => 2.0,
         {queue: "another", job_class: "FakeJob", priority: 1, due: "false"} => 1.0,
       )
+
+      # It's not easy to predict the number of dead tuples deterministically, so we just
+      # expect a float
+      expect(described_class::DeadTuples.values).to include(
+        {} => be_a(Float),
+      )
     end
 
     context "when called twice" do


### PR DESCRIPTION
When using the recursive job locking query, que is sensitive to the
number of dead tuples in the que_jobs table. This commit exposes a
metric that enables us to track this with time, and alert when it
reaches bad values.