### PR TITLE
Track whether a job lock query used a cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 *   Change default queue from '' to 'default'
 *   Expose `que_dead_tuples` metric
 *   Fix-up metric constant names
+*   Apply label to locker metrics to indicate cursor presence
 
 ### 1.0.0 (2018-07-20)
 


### PR DESCRIPTION
We want to identify the performance of job lock queries, and separate
the queries that make use of a cursor from those that don't. This labels
the AcquireTotal and AcquireSecondsTotal metrics with cursor=true|false,
to help us debug.