### PR TITLE
Do not freeze the SQL hash

### DIFF
--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -3,6 +3,7 @@
 # Prefactor: SQL hash was previously frozen, but we want to extend it and add some
 # queries that our strategies will use.
 module Que
+  # rubocop:disable Style/MutableConstant
   SQL = {
     # Locks a job using a Postgres recursive CTE [1].
     #
@@ -161,5 +162,6 @@ module Que
         WHERE locktype = 'advisory'
       ) pg USING (job_id)
     },
-  }.freeze
+  }
+  # rubocop:enable Style/MutableConstant
 end


### PR DESCRIPTION
Que extensions such as que-failure depend on extending this constant so
that [they can add their own SQL statements](https://github.com/gocardless/que-failure/blob/master/lib/que/failure/sql.rb) - this has always been the
intention as claimed by the comment at the top of the module but a
[recent Rubocop change](https://github.com/gocardless/que/commit/9c58766d48225bba506d28955c07eb169bca54e8) broke it.

This is preventing que from being used with que-failure and possibly other strategies as well (see https://circleci.com/gh/gocardless/payments-service/299916)