### PR TITLE
Enable prometheus gcstat gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,7 @@ platforms :rbx do
   gem 'rubysl', '~> 2.0'
 end
 
-gem 'prometheus-client',
-    git: 'https://github.com/gocardless/prometheus_client_ruby.git',
-    branch: 'gc_production_branch_do_not_push'
+gem 'prometheus-client', '~> 0.10.0.alpha'
+gem 'prometheus_gcstat', git: 'git@github.com:gocardless/prometheus_gcstat_ruby'
 
 gemspec

--- a/bin/que
+++ b/bin/que
@@ -114,6 +114,10 @@ if options.metrics_port
     )
 
     health_check = ->(_) { [200, {}, ["healthy"]] }
+
+    Prometheus::MemoryStats.
+      new(Prometheus::Client.registry).start(interval: 10.seconds, delay: 10.seconds)
+
     app = Rack::URLMap.new(
       "/" => Rack::Builder.new do
         use Que::Middleware::WorkerCollector, worker_group: worker_group


### PR DESCRIPTION
This will monitor memory consumption from the que workers.

We've tried to enable this through payments-service instead of here, but unfortunately, the forking nature of unicorn didn't make it possible.