### PR TITLE
Pass stop signal from Worker to Job

### DIFF
--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -70,9 +70,18 @@ module Que
     # have been passed in.
     def initialize(attrs)
       @attrs = attrs
+      @stop = false
     end
 
     attr_reader :attrs
+
+    def stop!
+      @stop = true
+    end
+
+    def stop?
+      @stop
+    end
 
     def run(*args)
       # In future, we want to raise NotImplementedError here to force subclasses to define

--- a/spec/helpers/interruptible_sleep_job.rb
+++ b/spec/helpers/interruptible_sleep_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class InterruptibleSleepJob < Que::Job
+  @log = []
+
+  class << self
+    attr_accessor :log
+  end
+
+  def run(duration)
+    5.times do
+      return if stop?
+
+      sleep(duration)
+      self.class.log << [:run, duration]
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require_relative "./helpers/exceptional_job"
 require_relative "./helpers/fake_job"
 require_relative "./helpers/que_job"
 require_relative "./helpers/sleep_job"
+require_relative "./helpers/interruptible_sleep_job"
 require_relative "./helpers/user"
 
 def postgres_now


### PR DESCRIPTION
This is an RFC PR that passes the stop signal from `Que::Worker` to `Que::Job`, and exposes this information to the job via the `Que::Job#stop?` method, which will return true if the job is about to be killed soon, and is in the timeout period. Running jobs can then access this method to decide if they should continue doing more work, or stop.

### Context

In [Nexus](https://github.com/gocardless/nexus) (our new service to submit files to the bank), we process and submit files to the bank as a series of Que jobs. We plan for a job to run periodically (by re-enqueuing itself) and pick up the backlog of files that need to be submitted to the bank and submit them inside one SFTP connection (this is to prevent the bank from rate limiting us). It would be quite risky for the file upload to the SFTP store to be interrupted, as depending on the bank, the file upload may or may not be idempotent (in some cases the bank moves the file as soon as it is uploaded). In these cases, we might have to resort to asking the bank if they received the file to prevent duplicate submissions.

However, a deployment would end up killing this upload job, and if at that time the job is in the middle of an SFTP upload, this would cause the problems mentioned above. To mitigate this issue, a possible solution I had in mind was to propagate the knowledge of the worker being asked to stop, to the job. With an appropriate timeout, the upload job can then check if it has been asked to stop before starting each upload, and terminate safely if it has.

In the current implementation of Que, `bin/que` [intercepts `SIGTERM`/`SIGINT`](https://github.com/gocardless/que/blob/e02e163b21e0d8d5d95aa275f65dbde31b3d4ba6/bin/que#L144), and then sets each [`Que::Worker`'s `@stop` variable](https://github.com/gocardless/que/blob/e02e163b21e0d8d5d95aa275f65dbde31b3d4ba6/lib/que/worker_group.rb#L32) to true, which it [checks before picking up any new work](https://github.com/gocardless/que/blob/e02e163b21e0d8d5d95aa275f65dbde31b3d4ba6/lib/que/worker.rb#L136). This solution proposes having a similar flag on `Que::Job`, which the job can then check at regular intervals to know if it should continue working or stop.

### tl;dr
We want a way to recover safely if a deployment happens while a Que job is in the middle of an SFTP upload, as the uploads to the bank aren't idempotent. The proposal is to let the job ask if it is about to be killed, so it can decide what to do.