### PR TITLE
Fix latency tracking

### DIFF
--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -177,7 +177,7 @@ module Que
               log_keys.merge(
                 event: "que_job.job_begin",
                 msg: "Job acquired, beginning work",
-                latency_seconds: job["latency"],
+                latency: job["latency"],
               )
             )
 

--- a/spec/lib/que/worker_spec.rb
+++ b/spec/lib/que/worker_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Que::Worker do
                  priority: 100,
                  queue: "default",
                  que_job_id: job.attrs["job_id"],
-                 latency_seconds: an_instance_of(Float),
+                 latency: an_instance_of(Float),
                ))
 
         expect(Que.logger).to receive(:info).


### PR DESCRIPTION
We've been logging the latency of Que jobs under the `latency_seconds`
field since [May 30][1]. However, this field is not in our logging
schema. We could add it but as far as I understand, unless stated
otherwise, all duration fields are implicitly expressed in seconds.

So, the field name should be `latency`. The good news is that this field
[already exists][2] in our logging schema, so we don't have anything
to do on that side.

[1]: https://github.com/gocardless/que/pull/46
[2]: https://github.com/gocardless/logging-template/blob/5360bde85ac59d19fdb3840b6569c6cfd214053a/templates/schema/schema.yaml#L593-L598