### PR TITLE
Be more resilient against unexpected time values.

### DIFF
--- a/lib/que/adapters/base.rb
+++ b/lib/que/adapters/base.rb
@@ -107,7 +107,13 @@ module Que
         # json
         114 => ->(value) { JSON_MODULE.load(value, create_additions: false) },
         # timestamp with time zone
-        1184 => Time.method(:parse),
+        1184 => ->(value) {
+          case value
+          when Time then value
+          when String then Time.parse(value)
+          else raise "Unexpected time class: #{value.class} (#{value.inspect})"
+          end
+        },
       }.freeze
 
       def cast_result(result)


### PR DESCRIPTION
Ported from two upstream que changes: https://github.com/que-rb/que/commit/5ddddd5ebac6153d7a683ef08c86bced8e03fb51 & https://github.com/que-rb/que/commit/87d40e7e1501346f4a92871c789df69863eaf94f

This seems to be breaking in Rails 6 ([example](https://circleci.com/gh/gocardless/payments-service/462931))