### PR TITLE
[BANKINT-231] Add failed label to gauge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 *   Fix-up metric constant names
 *   Apply label to locker metrics to indicate cursor presence
 *   Pin Prometheus to a GoCardless feature branch [link](https://github.com/gocardless/prometheus_client_ruby/tree/gc_production_branch_do_not_push) that is incompatible with upstream. This version has breaking API changes and includes new features such as pluggable data stores.
+*   Add `failed` label to queue collector middleware
 
 ### 1.0.0 (2018-07-20)
 


### PR DESCRIPTION
[Ticket](https://gocardless.atlassian.net/browse/BANKINT-231)

Add a `failed` label to queue view metrics to allow monitoring / alerting on failed jobs.

# Approach

Initially the idea here was to have separate gauge with its own SQL query to retrieve information. 
However by having a single gauge with multiple labels we do get some useful properties : 
- We can aggregate at either the job class or the queue level using `sum` in Promethesus.
- We do not have another SQL query to execute, so we shouldn't see performance changes.

To identify a job as failed we look for jobs where error count is greater than 0 and have the `retryable` flag set to false. This is in line with [our identification of failed jobs elsewhere](https://github.com/que-rb/que/pull/106).