### PR TITLE
que --lock-window <window> --lock-budget <budget>

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,13 @@ jobs:
   build:
     working_directory: ~/que
     docker:
-      - image: ruby:2.4.2
+      - image: ruby:2.6.5
         environment:
           PGDATABASE: que-test
           PGUSER: ubuntu
           PGPASSWORD: password
           PGHOST: localhost
-      - image: postgres:9.4.17
+      - image: postgres:11.2
         environment:
           POSTGRES_DB: que-test
           POSTGRES_USER: ubuntu
@@ -18,10 +18,10 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: gemfile-{{ .Branch }}-{{ checksum "Gemfile" }}
+          key: gemfile-265-{{ .Branch }}-{{ checksum "Gemfile" }}
       - run: bundle install
       - save_cache:
-          key: gemfile-{{ .Branch }}-{{ checksum "Gemfile" }}
+          key: gemfile-265-{{ .Branch }}-{{ checksum "Gemfile" }}
           paths:
             - "vendor/bundle"
       - run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 group :test do
   gem 'pry'
   gem 'pry-byebug'
-  gem 'rspec', '~> 2.14.1'
+  gem 'rspec', '~> 3.9'
 end
 
 platforms :rbx do

--- a/bin/que
+++ b/bin/que
@@ -30,6 +30,14 @@ OptionParser.new do |opts|
     options.cursor_expiry = cursor_expiry
   end
 
+  opts.on("--lock-window [WINDOW]", Float, "Duration (seconds) over which job lockers apply their budget") do |lock_window|
+    options.lock_window = lock_window
+  end
+
+  opts.on("--lock-budget [BUDGET]", Float, "Max duration (seconds) worker should spend locking jobs in --lock-window") do |lock_budget|
+    options.lock_budget = lock_budget
+  end
+
   opts.on("-c", "--worker-count [COUNT]", Integer, "Start this many threaded workers") do |worker_count|
     options.worker_count = worker_count
   end
@@ -94,7 +102,6 @@ end
 
 queue_name     = options.queue_name     || ENV["QUE_QUEUE"] || Que::Worker::DEFAULT_QUEUE
 wake_interval  = options.wake_interval  || ENV["QUE_WAKE_INTERVAL"]&.to_f
-cursor_expiry  = options.cursor_expiry  || 0
 worker_count   = options.worker_count   || 1
 timeout        = options.timeout
 
@@ -102,7 +109,9 @@ worker_group = Que::WorkerGroup.start(
   worker_count,
   queue: queue_name,
   wake_interval: wake_interval,
-  lock_cursor_expiry: cursor_expiry,
+  lock_cursor_expiry: options.cursor_expiry,
+  lock_window: options.lock_window,
+  lock_budget: options.lock_budget,
 )
 
 if options.metrics_port

--- a/lib/que.rb
+++ b/lib/que.rb
@@ -5,6 +5,7 @@ require "socket" # For hostname
 require_relative "que/adapters/base"
 require_relative "que/job"
 require_relative "que/job_timeout_error"
+require_relative "que/leaky_bucket"
 require_relative "que/locker"
 require_relative "que/migrations"
 require_relative "que/sql"

--- a/lib/que/leaky_bucket.rb
+++ b/lib/que/leaky_bucket.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Que
+  # Provide a mechanism to throttle resource usage, by specifying a target budget of
+  # resource time to be consumed over a rolling window.
+  #
+  # This is not thread-safe, and should be used by only one thread at any one time.
+  class LeakyBucket
+    def initialize(window:, budget:, clock: Clock)
+      @window = window
+      @budget = budget
+      @clock = clock
+      @ratio = budget / window
+      @remaining = 0.0
+      @last_refill = nil
+    end
+
+    class Clock
+      def self.now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      def self.sleep(duration)
+        Kernel.sleep(duration)
+      end
+    end
+
+    # Observe resource usage from within the provided block. This consumes time that
+    # remains in the bucket, and should only be called after the bucket has been refilled.
+    def observe
+      start = @clock.now
+      value = yield
+      duration = @clock.now - start
+      @remaining -= duration
+
+      value
+    end
+
+    # Wait for the bucket to be refilled, given the time that has elapsed since the last
+    # refill. This method will block until the remaining budget has become positive.
+    def refill
+      refill_time = @clock.now
+      time_since_refill = refill_time - (@last_refill || refill_time)
+      grant = @ratio * time_since_refill
+
+      @last_refill = refill_time
+      @remaining = [@budget, @remaining + grant].min
+
+      # Sleep long enough that the subsequent refill would provide a grant large enough to
+      # make our balance positive
+      if @remaining < 0.0
+        @clock.sleep(-@remaining / @ratio)
+      end
+    end
+  end
+end

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -38,12 +38,12 @@ module Que
       AcquireTotal = Prometheus::Client::Counter.new(
         :que_locker_acquire_total,
         docstring: "Counter of number of job lock queries executed",
-        labels: %i[queue cursor],
+        labels: %i[queue strategy],
       ),
       AcquireSecondsTotal = Prometheus::Client::Counter.new(
         :que_locker_acquire_seconds_total,
         docstring: "Seconds spent running job lock query",
-        labels: %i[queue cursor],
+        labels: %i[queue strategy],
       ),
     ].freeze
 
@@ -108,8 +108,8 @@ module Que
     private
 
     def lock_job
-      cursor = @cursor.zero? ? "false" : "true"
-      observe(AcquireTotal, AcquireSecondsTotal, cursor: cursor) do
+      strategy = @cursor.zero? ? "full" : "cursor"
+      observe(AcquireTotal, AcquireSecondsTotal, strategy: strategy) do
         Que.execute(:lock_job, [@queue, @cursor]).first
       end
     end

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "prometheus/client"
+require_relative "leaky_bucket"
 
 module Que
   # The Locker is used to acquire a job from the Postgres jobs table. The only method we
@@ -35,6 +36,11 @@ module Que
         docstring: "Seconds spent unlocking job advisory locks",
         labels: [:queue],
       ),
+      ThrottleSecondsTotal = Prometheus::Client::Counter.new(
+        :que_locker_throttle_seconds_total,
+        docstring: "Seconds spent throttling calls to lock jobs",
+        labels: [:queue],
+      ),
       AcquireTotal = Prometheus::Client::Counter.new(
         :que_locker_acquire_total,
         docstring: "Counter of number of job lock queries executed",
@@ -47,11 +53,15 @@ module Que
       ),
     ].freeze
 
-    def initialize(queue:, cursor_expiry:)
+    def initialize(queue:, cursor_expiry:, window: nil, budget: nil)
       @queue = queue
       @cursor_expiry = cursor_expiry
       @cursor = 0
       @cursor_expires_at = monotonic_now
+
+      if window && budget
+        @leaky_bucket = LeakyBucket.new(window: window, budget: budget)
+      end
     end
 
     # Acquire a job for the period of running the given block. Returning nil without
@@ -108,6 +118,10 @@ module Que
     private
 
     def lock_job
+      observe(nil, ThrottleSecondsTotal) do
+        @leaky_bucket.refill if @leaky_bucket
+      end
+
       strategy = @cursor.zero? ? "full" : "cursor"
       observe(AcquireTotal, AcquireSecondsTotal, strategy: strategy) do
         Que.execute(:lock_job, [@queue, @cursor]).first
@@ -133,9 +147,13 @@ module Que
       now = monotonic_now
       yield
     ensure
-      metric.increment(labels: labels.merge(queue: @queue))
-      metric_duration.increment(by: monotonic_now - now,
-                                labels: labels.merge(queue: @queue))
+      metric.increment(labels: labels.merge(queue: @queue)) if metric
+      if metric_duration
+        metric_duration.increment(
+          by: monotonic_now - now,
+          labels: labels.merge(queue: @queue)
+        )
+      end
     end
 
     def monotonic_now

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -119,15 +119,22 @@ module Que
     def initialize(
       queue: DEFAULT_QUEUE,
       wake_interval: DEFAULT_WAKE_INTERVAL,
-      lock_cursor_expiry: DEFAULT_LOCK_CURSOR_EXPIRY
+      lock_cursor_expiry: DEFAULT_LOCK_CURSOR_EXPIRY,
+      lock_window: nil,
+      lock_budget: nil
     )
       @queue = queue
       @wake_interval = wake_interval
-      @locker = Locker.new(queue: queue, cursor_expiry: lock_cursor_expiry)
       @tracer = LongRunningMetricTracer.new(self)
       @stop = false # instruct worker to stop
       @stopped = false # mark worker as having stopped
       @current_running_job = nil
+      @locker = Locker.new(
+        queue: queue,
+        cursor_expiry: lock_cursor_expiry,
+        window: lock_window,
+        budget: lock_budget,
+      )
     end
 
     attr_reader :metrics

--- a/spec/lib/que/leaky_bucket_spec.rb
+++ b/spec/lib/que/leaky_bucket_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Que::LeakyBucket do
+  subject(:bucket) { described_class.new(window: window, budget: budget, clock: clock) }
+
+  let(:window) { 5.0 }
+  let(:budget) { 1.0 }
+  let(:clock)  { FakeClock.new }
+
+  # Provide a test clock interface, allowing the observations and sleeps made by the
+  # bucket to advance test time.
+  FakeClock = Class.new do
+    def initialize
+      @now = 0.0
+    end
+
+    attr_reader :now
+
+    def sleep(duration)
+      @now += duration
+    end
+
+    def advance(duration)
+      @now += duration
+    end
+  end
+
+  def measure_total_work(clock, bucket, runtime:, work_duration: 0.05)
+    total_work = 0.0
+    until clock.now > runtime
+      bucket.refill
+      bucket.observe do
+        duration = Random.rand(work_duration)
+        clock.advance(duration)
+        total_work += duration
+      end
+    end
+
+    total_work
+  end
+
+  context "when working as much as possible" do
+    subject do
+      measure_total_work(clock, bucket, runtime: 10.0)
+    end
+
+    context "runtime 10s, window 10s, budget 2s" do
+      let(:runtime) { 10.0 }
+      let(:window) { 10.0 }
+      let(:budget) { 2.0 }
+
+      it { is_expected.to be_within(0.2).of(2.0) }
+    end
+
+    context "runtime 10s, window 5s, budget 4s" do
+      let(:runtime) { 10.0 }
+      let(:window) { 5.0 }
+      let(:budget) { 4.0 }
+
+      it { is_expected.to be_within(0.2).of(8.0) }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,7 @@ require_relative "./helpers/interruptible_sleep_job"
 require_relative "./helpers/user"
 
 def postgres_now
-  now = ActiveRecord::Base.connection.execute("SELECT NOW();")[0]["now"]
-  Time.parse(now)
+  ActiveRecord::Base.connection.execute("SELECT NOW();")[0]["now"]
 end
 
 def establish_database_connection


### PR DESCRIPTION
Enable users to throttle Que locking queries to better handle situations
where job acquisition becomes expensive. The LeakyBucket class attempts
to fairly throttle the lock acquisition by sleeping during the lock
process, aiming to satisfy the at-most budget seconds of lock work per
window.