### PR TITLE
Materialized view for job counts

### DIFF
--- a/lib/que/migrations.rb
+++ b/lib/que/migrations.rb
@@ -5,7 +5,7 @@ module Que
     # In order to ship a schema change, add the relevant up and down sql files
     # to the migrations directory, and bump the version both here and in the
     # add_que generator template.
-    CURRENT_VERSION = 4
+    CURRENT_VERSION = 5
 
     class << self
       # rubocop:disable Metrics/AbcSize

--- a/lib/que/migrations/5/down.sql
+++ b/lib/que/migrations/5/down.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW que_jobs_summary;

--- a/lib/que/migrations/5/up.sql
+++ b/lib/que/migrations/5/up.sql
@@ -1,0 +1,9 @@
+CREATE MATERIALIZED VIEW que_jobs_summary
+AS (
+  select queue, job_class, priority
+       , (case when (retryable AND run_at < now()) then 'true' else 'false' end) as due
+       , (case when (NOT retryable AND error_count > 0) then 'true' else 'false' end) as failed
+       , count(*)
+       from que_jobs
+   group by 1, 2, 3, 4, 5
+);

--- a/spec/lib/que/middleware/queue_collector_spec.rb
+++ b/spec/lib/que/middleware/queue_collector_spec.rb
@@ -44,12 +44,6 @@ RSpec.describe Que::Middleware::QueueCollector do
         { queue: "default", job_class: "FakeJob", priority: "20",
           due: "false", failed:  "true" } => 1.0,
       )
-
-      # It's not easy to predict the number of dead tuples deterministically, so we just
-      # expect a float
-      expect(described_class::DeadTuples.values).to include(
-        {} => be_a(Float),
-      )
     end
 
     context "when called twice" do


### PR DESCRIPTION
Instead of re-computing this every time we scrape, use a materialized
view to avoid hurting the database. This makes it more sensible to
output queue metrics from each Que worker, too.