### PR TITLE
Assorted fixes for the leaky bucket

### DIFF
--- a/lib/que/leaky_bucket.rb
+++ b/lib/que/leaky_bucket.rb
@@ -29,11 +29,12 @@ module Que
     # remains in the bucket, and should only be called after the bucket has been refilled.
     def observe
       start = @clock.now
-      value = yield
+      result = yield
+    ensure
       duration = @clock.now - start
       @remaining -= duration
 
-      value
+      result
     end
 
     # Wait for the bucket to be refilled, given the time that has elapsed since the last
@@ -51,6 +52,15 @@ module Que
       if @remaining < 0.0
         @clock.sleep(-@remaining / @ratio)
       end
+    end
+
+    private
+
+    def catch_error(&block)
+      result = block.call
+      [result, nil]
+    rescue StandardError => err
+      [result, err]
     end
   end
 end


### PR DESCRIPTION
The previous commit didn't actually use the observe method of the leaky
bucket. This meant the bucket never tracked any work, so while the
bucket itself worked, it never took any throttling action.

We also provide an improvement to the observe method of the leaky bucket
to ensure we throttle things even when the lock timeout throws an
exception.