### PR TITLE
Cherry pick [chanks/que#166][166]

### DIFF
--- a/lib/que/adapters/active_record.rb
+++ b/lib/que/adapters/active_record.rb
@@ -63,7 +63,13 @@ module Que
       private
 
       def checkout_activerecord_adapter(&block)
-        ::ActiveRecord::Base.connection_pool.with_connection(&block)
+        if defined?(::Rails.application.executor)
+          ::Rails.application.executor.wrap do
+            ::ActiveRecord::Base.connection_pool.with_connection(&block)
+          end
+        else
+          ::ActiveRecord::Base.connection_pool.with_connection(&block)
+        end
       end
     end
   end


### PR DESCRIPTION
This should help with using a secondary database connection pool inside
Que jobs.

Original issue is [chanks/que#166][166]

[166]: https://github.com/que-rb/que/issues/166