### PR TITLE
Support correct deserialization of floats

### DIFF
--- a/lib/que/adapters/base.rb
+++ b/lib/que/adapters/base.rb
@@ -106,6 +106,8 @@ module Que
         23 => proc(&:to_i),
         # json
         114 => ->(value) { JSON_MODULE.load(value, create_additions: false) },
+        # float
+        701 => proc(&:to_f),
         # timestamp with time zone
         1184 => ->(value) {
           case value


### PR DESCRIPTION
Without this, floats are returned as strings back to que, causing the
'latency' argument of the `lock_job` query to be incorrectly
deserialised when not using the ActiveRecord adapter (as ActiveRecord
will automatically cast some values to the correct type).

A full list of datatypes and their internal constant representation
can be found in https://jdbc.postgresql.org/documentation/publicapi/constant-values.html,
but looks like `FLOAT8` is what's being returned in most cases.