### PR TITLE
Correctly handle booleans for adapters that do their own type casting

### DIFF
--- a/lib/que/adapters/base.rb
+++ b/lib/que/adapters/base.rb
@@ -97,7 +97,12 @@ module Que
 
       CAST_PROCS = {
         # booleans
-        16 => "t".method(:==),
+        16 => ->(value) {
+          case value
+          when String then value == "t"
+          else !!value
+          end
+        },
         # bigint
         20 => proc(&:to_i),
         # smallint

--- a/spec/lib/que/job_spec.rb
+++ b/spec/lib/que/job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Que::Job do
         queue: "default",
         priority: 100,
         job_class: "Que::Job",
-        retryable: false,
+        retryable: true,
         run_at: run_at,
         args: ["hello"],
       )


### PR DESCRIPTION
This is especially true in ActiveRecord 5+ as they are already returning
booleans in postgres as ruby booleans. This causes the field type on the
PG raw resultset to be set to bool (`16`) and therefore all booleans end
up being inverted because `'t' == true` returns `false`.

See #60 for more context

Upstream que also has had the same fix a while ago: https://github.com/que-rb/que/commit/88d1cae8249afc091438e22f52444bccdefe5c1a