### PR TITLE
Remove bundler as a dev dependency

### DIFF
--- a/que.gemspec
+++ b/que.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "prometheus-client"
 
   spec.add_dependency "rack", "~> 2.0"
-  spec.add_development_dependency "bundler", "~> 1.3"
 
   spec.add_runtime_dependency "activesupport"
 end


### PR DESCRIPTION
We don't need to pin bundler to any version here, especially the 1.3
version which is about 8 years old at this stage.
This means we can run `bundle install` again for que without running
into conflicts as most of everything runs on bundler 2.x.

Alternatively we could pin this to '~> 2` but in every other gem we own
we're not doing this explicitly and I think it works well in practice