### PR TITLE
Use CircleCI's docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     working_directory: ~/que
     docker:
-      - image: ruby:2.6.5
+      - image: circleci/ruby:2.6.5
         environment:
           PGDATABASE: que-test
           PGUSER: ubuntu


### PR DESCRIPTION
We're getting warnings that we're not authenticated against docker hub
and they'll be restricting access to these images at some point.