### PR TITLE
Export metrics for worker groups

### DIFF
--- a/lib/que/middleware/worker_collector.rb
+++ b/lib/que/middleware/worker_collector.rb
@@ -15,11 +15,13 @@ module Que
         @worker_group = options.fetch(:worker_group)
         @registry = options.fetch(:registry, Prometheus::Client.registry)
 
+        register(*WorkerGroup::METRICS)
         register(*Worker::METRICS)
         register(*Locker::METRICS)
       end
 
       def call(env)
+        @worker_group.collect_metrics
         @worker_group.workers.each(&:collect_metrics)
         @app.call(env)
       end


### PR DESCRIPTION
We ran into a case last week where one of our workers failed to check
out a connection from ActiveRecord, leaving a worker running without
actually processing any jobs. Turns out that we have limited visibility
into this and it's possible this is happening more frequently but we
haven't noticed (yet) as no errors are reported anywhere and if you have
more than one worker (as in, more than one executable worker) things
will be working normally, though with a lower throughput.
The fact that the error is completely hidden is a bit worrying, but I'll look
at that separately. This PR focuses on the metrics visibility aspect of
the problem.

Each que "worker" (as an executable) will spawn a _worker group_, which is
a collection of threads that will end up picking up the jobs on the
configured queue. Practically speaking, each of these threads is a
worker for the configured queue.

We are already exporting metrics for individual worker threads, but we
have no visibility into the worker group itself. In situations where one
or more threads fail in a group, the process is left with less capacity
than originally intended but as it stands we have no visibility into how
often does that happen and when.

To that extent, this commit adds two gauges as Prometheus metrics:

- `que_worker_group_expected_workers_count`: how many workers we wanted
  this process to run
- `que_worker_group_active_workers_count`: how many workers are
  currently active

One caveat is that `que_worker_group_active_workers_count` is also counting
threads that we have intentionally stopped as otherwise metrics would
be skewed during deploys.

I tried this internally in staging and [seems to be working](https://grafana.gocardless.io/explore?orgId=1&left=%5B%221608563729681%22,%221608564768026%22,%22Thanos%20Querier%22,%7B%22expr%22:%22sum%20by%20(release,%20instance)%20(que_worker_group_active_workers_count)%22%7D,%7B%22expr%22:%22sum%20by%20(release,%20instance)%20(que_worker_group_expected_workers_count)%22,%22hide%22:false%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D).

As a side note, there's no existing tests for the worker group class and
given it deals with threads, writing some it's complicated. I'll probably
pick this part again as I try to make the error case described in the
first paragraph more visible.