### PR TITLE
Do not kill the worker thread if we can't checkout a PG connection

### DIFF
--- a/lib/que/adapters/active_record.rb
+++ b/lib/que/adapters/active_record.rb
@@ -5,6 +5,8 @@ module Que
     class ActiveRecord < Base
       def checkout
         checkout_activerecord_adapter { |conn| yield conn.raw_connection }
+      rescue ::ActiveRecord::ConnectionTimeoutError => e
+        raise UnavailableConnection
       end
 
       def wake_worker_after_commit

--- a/lib/que/adapters/base.rb
+++ b/lib/que/adapters/base.rb
@@ -10,6 +10,8 @@ module Que
     autoload :Pond,           "que/adapters/pond"
     autoload :Sequel,         "que/adapters/sequel"
 
+    class UnavailableConnection < StandardError; end
+
     class Base
       def initialize(_thing = nil)
         @prepared_statements = {}

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -237,7 +237,7 @@ module Que
           :job_worked
         end
       end
-    rescue PG::Error => _error
+    rescue PG::Error, Adapters::UnavailableConnection => _error
       # In the event that our Postgres connection is bad, we don't want that error to halt
       # the work loop. Instead, we should let the work loop sleep and retry.
       :postgres_error

--- a/spec/lib/que/worker_spec.rb
+++ b/spec/lib/que/worker_spec.rb
@@ -124,6 +124,17 @@ RSpec.describe Que::Worker do
           expect(subject).to eq(:postgres_error)
         end
       end
+
+      context "when we can't checkout a new connection" do
+        it "rescues it and returns an error" do
+          FakeJob.enqueue(1)
+
+          expect(Que).
+            to receive(:execute).with(:lock_job, ["default", 0]).
+              and_raise(ActiveRecord::ConnectionTimeoutError)
+          expect(subject).to eq(:postgres_error)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
It's possible for the adapter to not being able to checkout a new PG
connection. In the case of AR specifically, this can raise a few
different exceptions depending on what's the reason behind the failure.

Currently when AR raise a connection timeout, the thread won't catch
that exception, meaning that it will crash and leave the worker with one
less thread available to process job. In cases where we only use a
single thread (the default case), this means it's possible for a worker
to be up and running but not actually processing any new jobs.

This commit introduces a way to recognise those exceptions and let the
thread retry on failure, so that we're not left with stale workers.