### PR TITLE
Use latest version of Que migration by default

### DIFF
--- a/lib/generators/que/templates/add_que.rb
+++ b/lib/generators/que/templates/add_que.rb
@@ -3,7 +3,7 @@
 class AddQue < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def self.up
     # The current version as of this migration's creation.
-    Que.migrate! version: 4
+    Que.migrate!
   end
 
   def self.down


### PR DESCRIPTION
When no argument is provided, it uses latest version by default:
https://github.com/gocardless/que/blob/29646821821d1d18ac2944584e55255c57d8f957/lib/que.rb#L105
which means we don't need to keep this file in sync (it is one version behind right now)