### PR TITLE
Explicitly require AR errors

### DIFF
--- a/lib/que/adapters/active_record.rb
+++ b/lib/que/adapters/active_record.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "pg"
+require "active_record/errors"
 
 module Que
   module Adapters


### PR DESCRIPTION
Otherwise we may run into missing require errors in anything that uses que.