### PR TITLE
Use constantize to check AR errors

### DIFF
--- a/lib/que/adapters/active_record.rb
+++ b/lib/que/adapters/active_record.rb
@@ -6,19 +6,19 @@ module Que
   module Adapters
     class ActiveRecord < Base
       AR_UNAVAILABLE_CONNECTION_ERRORS = [
-        ::ActiveRecord::ConnectionTimeoutError,
-        ::ActiveRecord::ConnectionNotEstablished,
-        ::PG::ConnectionBad,
-        ::PG::ServerError,
-        ::PG::UnableToSend,
+        "::ActiveRecord::ConnectionTimeoutError",
+        "::ActiveRecord::ConnectionNotEstablished",
+        "::PG::ConnectionBad",
+        "::PG::ServerError",
+        "::PG::UnableToSend",
       ].freeze
 
       def checkout
         checkout_activerecord_adapter { |conn| yield conn.raw_connection }
-      rescue *AR_UNAVAILABLE_CONNECTION_ERRORS => e
+      rescue *AR_UNAVAILABLE_CONNECTION_ERRORS.map(&:constantize) => e
         raise UnavailableConnection, e
       rescue ::ActiveRecord::StatementInvalid => e
-        raise e unless AR_UNAVAILABLE_CONNECTION_ERRORS.include?(e.cause.class)
+        raise e unless AR_UNAVAILABLE_CONNECTION_ERRORS.include?(e.cause.class.to_s)
 
         # ActiveRecord::StatementInvalid is one of the most generic exceptions AR can
         # raise, so we catch it and only handle the specific nested exceptions.


### PR DESCRIPTION
We're seeing some errors on startup of our services where these constants arent defined yet leading to errors like

```ruby
/Users/joesouthan/gc/que/lib/que/adapters/active_record.rb:11:in `<class:ActiveRecord>': uninitialized constant ActiveRecord::ConnectionTimeoutError (NameError)
        from /Users/joesouthan/gc/que/lib/que/adapters/active_record.rb:9:in `<module:Adapters>'
        from /Users/joesouthan/gc/que/lib/que/adapters/active_record.rb:8:in `<module:Que>'
        from /Users/joesouthan/gc/que/lib/que/adapters/active_record.rb:7:in `<main>'

```﻿
