### PR TITLE
Rescue `NotImplementedError`s

### DIFF
--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -216,7 +216,7 @@ module Que
                 duration: duration,
               )
             )
-          rescue StandardError, JobTimeoutError => error
+          rescue StandardError, NotImplementedError, JobTimeoutError => error
             JobErrorTotal.increment(labels: labels)
             Que.logger&.error(
               log_keys.merge(


### PR DESCRIPTION
When a job fails, the worker (thread) processing the job normally marks
the job as failed and picks up another job. That is unless the job fails
with an error that doesn't inherit from `StandardError` (or
`JobTimeoutError`).

`NotImplementedError` is one of those errors, which means that if
a job fails with this error, the worker will crash, causing some
[headaches][1].

This error is widely [(ab)used][2] in Rails and in our own codebase so
we're better off rescuing it.

Ref: https://gocardless.slack.com/archives/C01JMFWJW2Z/p1632300910114400

[1]: https://gocardless.slack.com/archives/C01JMFWJW2Z/p1632300910114400
[2]: http://chrisstump.online/2016/03/23/stop-abusing-notimplementederror/