### PR TITLE
Remove vestigial call to Que.log

### DIFF
--- a/lib/que/adapters/base.rb
+++ b/lib/que/adapters/base.rb
@@ -87,7 +87,7 @@ module Que
             # objects to refer to new backends, so recover as well as we can.
 
             unless prepared_just_now
-              Que.log level: "warn", event: "reprepare_statement", name: name
+              Que.logger&.warn event: "reprepare_statement", name: name
               statements[name] = false
               retry
             end


### PR DESCRIPTION
Lawrence removed this helper a long time ago but missed that it was called within Que itself.

I think this will only trigger when you create a new database which is why we never noticed it.