### PR TITLE
Contribute improvements back upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Que
 
+This repo is a fork of https://github.com/que-rb/que.
+
 **TL;DR: Que is a high-performance alternative to DelayedJob or QueueClassic that improves the reliability of your application by protecting your jobs with the same [ACID guarantees](https://en.wikipedia.org/wiki/ACID) as the rest of your data.**
 
 Que ("keɪ", or "kay") is a queue for Ruby and PostgreSQL that manages jobs using [advisory locks](http://www.postgresql.org/docs/current/static/explicit-locking.html#ADVISORY-LOCKS), which gives it several advantages over other RDBMS-backed queues:


### PR DESCRIPTION
Hey folks!

You don't have issues enabled on this repo, so I've had to open a PR for this discussion.

We at @greensync have taken over maintenance of Que, the upstream project of your fork =) I went through the forks a couple of months ago to see if there were any useful changes to bring in, but somehow I missed this one! I see you folks have made a whole bunch of improvements, which is fantastic! Now that the upstream project is actively being maintained again, I was hoping you'd be open to helping combine your improvements back upstream?

Sadly, your fork is of such an old version of Que that integrating the changes back upstream is probably going to be a bit of a challenge now. I'm curious - why did you feel the need to fork rather than become maintainers? We faced that choice ourselves, but opted to try for the latter, and thankfully it was approved.

I'd like to start by enumerating what the improvements have been. I see you've added Prometheus metrics, which would be quite handy. An issue was opened two years ago by one of you suggesting contributing that (and other improvements) upstream (https://github.com/que-rb/que/issues/267) which I've just noticed.

I think we should open an issue for each feature, and then create a PR for each one.

Cheers,

-Brendan