### PR TITLE
Deduplicate log message string in worker

### DIFF
--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -145,7 +145,7 @@ module Que
         loop do
           case event = work
           when :job_not_found, :postgres_error
-            Que.logger&.info(event: "que.#{event}", wake_interval: @wake_interval)
+            Que.logger&.info(event: -+"que.#{event}", wake_interval: @wake_interval)
             @tracer.trace(SleepingSecondsTotal, queue: @queue) { sleep(@wake_interval) }
           when :job_worked
             nil # immediately find a new job to work
@@ -158,8 +158,6 @@ module Que
       @stopped = true
     end
 
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     def work
       Que.adapter.checkout do
         @locker.with_locked_job do |job|
@@ -243,8 +241,6 @@ module Que
       # the work loop. Instead, we should let the work loop sleep and retry.
       :postgres_error
     end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
 
     def stop!
       @stop = true


### PR DESCRIPTION
Despite using `# frozen_string_literals: true`, Ruby doesn't automatically deduplicate interpolated string literals. Thus if the same job is run say, about 35,000 times, you'll end up with 35,000 identical copies of `que.some_job_related_string` in memory! This change makes use of the `#-@` and `#+@` methods on `String` to unfreeze and then refreeze the string with deduplication (the same deduplication automatically used internally by Ruby for things like hash keys)

The result is that when profiling the `payments-service/components/que/spec/que_commit_spec.rb[1:1]` ("it produces optimal result as specified by LPT") test, queue's retained memory usage dropped from 5.60kB to 40.00B, implying a potential daily saving of nearly 20MB for a certain screening related worker owned by the CAML team which will remain nameless >_>