### PR TITLE
Downgrade que.job_not_found log to debug

### DIFF
--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -144,8 +144,11 @@ module Que
       @tracer.trace(RunningSecondsTotal, queue: @queue) do
         loop do
           case event = work
-          when :job_not_found, :postgres_error
-            Que.logger&.info(event: "que.#{event}", wake_interval: @wake_interval)
+          when :postgres_error
+            Que.logger&.info(event: "que.postgres_error", wake_interval: @wake_interval)
+            @tracer.trace(SleepingSecondsTotal, queue: @queue) { sleep(@wake_interval) }
+          when :job_not_found
+            Que.logger&.debug(event: "que.job_not_found", wake_interval: @wake_interval)
             @tracer.trace(SleepingSecondsTotal, queue: @queue) { sleep(@wake_interval) }
           when :job_worked
             nil # immediately find a new job to work


### PR DESCRIPTION
This log happens when there is no work on the workers queue and isn't particularly useful in production. If we want to assess if the queue is being over provisioned we should instead look at the SleepingSecondsTotal metric.

I've preserved the postgres_error log at its current level, its likely this is at the wrong level also and should be higher but its likely we'd see other more useful errors alongside this.