### PR TITLE
Add a default value for secondary_queues

### DIFF
--- a/bin/que
+++ b/bin/que
@@ -86,12 +86,13 @@ rescue LoadError
   $stdout.puts "Could not load file '#{file}'"
 end
 
-log_level      = options.log_level     || ENV["QUE_LOG_LEVEL"]           || "info"
-queue_name     = options.queue_name    || ENV["QUE_QUEUE"]               || Que::Worker::DEFAULT_QUEUE
-wake_interval  = options.wake_interval || ENV["QUE_WAKE_INTERVAL"]&.to_f || Que::Worker::DEFAULT_WAKE_INTERVAL
-cursor_expiry  = options.cursor_expiry || wake_interval
-worker_count   = options.worker_count  || 1
-timeout        = options.timeout
+log_level        = options.log_level     || ENV["QUE_LOG_LEVEL"]           || "info"
+queue_name       = options.queue_name    || ENV["QUE_QUEUE"]               || Que::Worker::DEFAULT_QUEUE
+wake_interval    = options.wake_interval || ENV["QUE_WAKE_INTERVAL"]&.to_f || Que::Worker::DEFAULT_WAKE_INTERVAL
+cursor_expiry    = options.cursor_expiry || wake_interval
+worker_count     = options.worker_count  || 1
+timeout          = options.timeout
+secondary_queues = options.secondary_queues  || []
 
 Que.logger ||= Logger.new(STDOUT)
 
@@ -116,7 +117,7 @@ worker_group = Que::WorkerGroup.start(
   lock_cursor_expiry: cursor_expiry,
   lock_window: options.lock_window,
   lock_budget: options.lock_budget,
-  secondary_queues: options.secondary_queues,
+  secondary_queues: secondary_queues,
 )
 
 if options.metrics_port


### PR DESCRIPTION
This avoids passing a nil values into Locker which will cause an issue starting the process.