### PR TITLE
Add metric label for primary_queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,23 @@ Regarding contributions, one of the project's priorities is to keep Que as simpl
 
 ### Specs
 
+Note that running specs requires a running Postgres instance. 
+
+To start the server in a docker container perform the following:
+
+```
+docker run -p5432:5432 --env POSTGRES_USER=ubuntu --env POSTGRES_PASSWORD=password  --env POSTGRES_DB=que-test postgres:11.2
+```
+
+Now inform the test suite where Postgres is running using environment variables
+
+```
+export PGDATABASE=que-test
+export PGUSER=ubuntu
+export PGPASSWORD=password
+export PGHOST=localhost
+```
+
 A note on running specs - Que's worker system is multithreaded and therefore prone to race conditions (especially on interpreters without a global lock, like Rubinius or JRuby). As such, if you've touched that code, a single spec run passing isn't a guarantee that any changes you've made haven't introduced bugs. One thing I like to do before pushing changes is rerun the specs many times and watching for hangs. You can do this from the command line with something like:
 
     for i in {1..1000}; do bundle exec rspec -b --seed $i; done

--- a/spec/lib/que/worker_spec.rb
+++ b/spec/lib/que/worker_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Que::Worker do
                  msg: "Job acquired, beginning work",
                  priority: 100,
                  queue: "default",
+                 primary_queue: "default",
                  que_job_id: job.attrs["job_id"],
                  latency: an_instance_of(Float),
                ))
@@ -43,6 +44,7 @@ RSpec.describe Que::Worker do
                  msg: "Successfully worked job",
                  priority: 100,
                  queue: "default",
+                 primary_queue: "default",
                  que_job_id: job.attrs["job_id"],
                ))
         subject
@@ -73,6 +75,7 @@ RSpec.describe Que::Worker do
                    msg: "Job acquired, beginning work",
                    priority: 100,
                    queue: "default",
+                   primary_queue: "default",
                    que_job_id: job.attrs["job_id"],
                    latency: an_instance_of(Float),
                    custom_log_1: 1,
@@ -89,6 +92,7 @@ RSpec.describe Que::Worker do
                    msg: "Successfully worked job",
                    priority: 100,
                    queue: "default",
+                   primary_queue: "default",
                    que_job_id: job.attrs["job_id"],
                    custom_log_1: 1,
                    custom_log_2: "test-log",


### PR DESCRIPTION
Follow on from https://github.com/gocardless/que/pull/93

Allows us to break down when a queue is stealing work from another queue