### PR TITLE
[RFC] Allow selection from multiple queues at the application level

### DIFF
--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -56,14 +56,17 @@ module Que
     def initialize(queue:, cursor_expiry:, window: nil, budget: nil, secondary_queues: [])
       @queue = queue
       @cursor_expiry = cursor_expiry
-      @cursor = 0
-      @cursor_expires_at = monotonic_now
+      @queue_cursors = {}
+      @queue_expires_at = {}
       @secondary_queues = secondary_queues
       @consolidated_queues = Array.wrap(queue).concat(secondary_queues)
 
       # Create a bucket that has 100% capacity, so even when we don't apply a limit we
       # have a valid bucket that we can use everywhere
       @leaky_bucket = LeakyBucket.new(window: window || 1.0, budget: budget || 1.0)
+
+      # Initialise the cursor maps
+      handle_expired_cursors!
     end
 
     # Acquire a job for the period of running the given block. Returning nil without
@@ -71,21 +74,31 @@ module Que
     # yielding with nil means there were no jobs to lock, and the worker will pause before
     # retrying.
     def with_locked_job
-      reset_cursor if cursor_expired?
+      handle_expired_cursors!
 
-      job = lock_job
+      job = @consolidated_queues.lazy.filter_map do |queue|
+        cursor = @queue_cursors.fetch(queue, 0)
+        found_job = lock_job_in(queue, cursor)
 
-      # Becuase we were using a cursor when we tried to lock this job, if we fail to find
-      # a job it is not necessarily the case that there aren't jobs in the queue. We may
-      # have been excluding candidate jobs due to the cursor that are now due to be
-      # worked.
-      #
-      # We should attempt to lock again after resetting our cursor to make sure we include
-      # jobs that were excluded in the first attempt.
-      if job.nil? && @cursor != 0
-        reset_cursor
-        job = lock_job
-      end
+        # Because we were using a cursor when we tried to lock this job, if we fail to
+        # find a job it is not necessarily the case that there aren't jobs in the
+        # queue. We may have been excluding candidate jobs due to the cursor that
+        # are now due to be worked.
+        #
+        # We should attempt to lock again after resetting our cursor to make sure we
+        # include jobs that were excluded in the first attempt.
+        #
+        # We leave the cursors for subsequant queues alone however. The idea there is
+        # that if we've touched a subsequant queue at some point and gotten on a cursor
+        # then work appears on a more pressing queue then `handle_expired_cursors` will
+        # do the appropriate book keeping.
+        if found_job.nil? && cursor != 0
+          reset_cursor_for!(queue)
+          found_job = lock_job_in(queue, 0)
+        end
+
+        found_job
+      end.first
 
       # Check that the job hasn't just been worked by another worker (it's possible to
       # lock a job that's just been destroyed because pg locks don't obey MVCC). If it has
@@ -102,7 +115,7 @@ module Que
       # acquiring the lock on it.
       return if job && !exists?(job)
 
-      @cursor = job[:job_id] if job
+      @queue_cursors[job[:queue]] = job[:job_id] if job
 
       yield job
     ensure
@@ -115,15 +128,15 @@ module Que
 
     private
 
-    def lock_job
+    def lock_job_in(queue, cursor)
       observe(nil, ThrottleSecondsTotal) { @leaky_bucket.refill }
-      @leaky_bucket.observe { execute_lock_job }
+      @leaky_bucket.observe { execute_lock_job_in(queue, cursor) }
     end
 
-    def execute_lock_job
-      strategy = @cursor.zero? ? "full" : "cursor"
+    def execute_lock_job_in(queue, cursor)
+      strategy = cursor.zero? ? "full" : "cursor"
       observe(AcquireTotal, AcquireSecondsTotal, strategy: strategy) do
-        lock_job_query
+        lock_job_query(queue, cursor)
       end
     end
 
@@ -133,40 +146,31 @@ module Que
       end
     end
 
-    def lock_job_query
-      if @secondary_queues.any?
-        Que.execute(
-          :queue_permissive_lock_job,
-          [
-            "{" + @consolidated_queues.join(",") + "}",
-            @cursor,
-          ]
-        ).first
-      else
-        Que.execute(:lock_job, [@queue, @cursor]).first
+    def lock_job_query(queue, cursor)
+      Que.execute(:lock_job, [queue, cursor]).first
+    end
+
+    def handle_expired_cursors!
+      @consolidated_queues.each do |queue|
+        queue_cursor_expires_at = @queue_expires_at.fetch(queue, monotonic_now)
+        reset_cursor_for!(queue) if queue_cursor_expires_at < monotonic_now
       end
     end
 
-    def cursor_expired?
-      @cursor_expires_at < monotonic_now
-    end
-
-    def reset_cursor
-      @cursor = 0
-      @cursor_expires_at = monotonic_now + @cursor_expiry
+    def reset_cursor_for!(queue)
+      @queue_cursors[queue] = 0
+      @queue_expires_at[queue] = monotonic_now + @cursor_expiry
     end
 
     def observe(metric, metric_duration, labels = {})
       now = monotonic_now
       yield
     ensure
-      metric.increment(labels: labels.merge(queue: @queue)) if metric
-      if metric_duration
-        metric_duration.increment(
-          by: monotonic_now - now,
-          labels: labels.merge(queue: @queue),
-        )
-      end
+      metric&.increment(labels: labels.merge(queue: @queue))
+      metric_duration&.increment(
+        by: monotonic_now - now,
+        labels: labels.merge(queue: @queue),
+      )
     end
 
     def monotonic_now

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -84,55 +84,6 @@ module Que
       LIMIT 1
     },
 
-    # instead of keeping this worker in a exclusive queue mode let it take work
-    # from defined secondary_queues with work available.
-    queue_permissive_lock_job: %{
-      WITH RECURSIVE jobs AS (
-        SELECT (j).*, pg_try_advisory_lock((j).job_id) AS locked
-        FROM (
-          SELECT j
-          FROM que_jobs AS j
-          WHERE job_id >= $2
-          AND queue = ANY($1::text[])
-          AND run_at <= now()
-          AND retryable = true
-          ORDER BY
-            array_position($1::text[], queue),
-            priority,
-            run_at,
-            job_id
-          LIMIT 1
-        ) AS t1
-        UNION ALL (
-          SELECT (j).*, pg_try_advisory_lock((j).job_id) AS locked
-          FROM (
-            SELECT (
-              SELECT j
-              FROM que_jobs AS j
-              WHERE run_at <= now()
-              AND queue = ANY($1::text[])
-              AND retryable = true
-              AND (priority, run_at, job_id) > (jobs.priority, jobs.run_at, jobs.job_id)
-              ORDER BY
-                array_position($1::text[], queue),
-                priority,
-                run_at,
-                job_id
-              LIMIT 1
-            ) AS j
-            FROM jobs
-            WHERE jobs.job_id IS NOT NULL
-            LIMIT 1
-          ) AS t1
-        )
-      )
-      SELECT queue, priority, run_at, job_id, job_class, retryable, args, error_count,
-             extract(epoch from (now() - run_at)) as latency
-      FROM jobs
-      WHERE locked
-      LIMIT 1
-    },
-
     check_job: %(
       SELECT 1 AS one
       FROM   que_jobs


### PR DESCRIPTION
Rather than attempt to modify the query to select one job from multiple queues in the DB we instead call into the DB multiple times.

This means we can rely on the existing query planning used for single queue collections while still getting prioritised work stealing.

It comes with two trade offs:
1. This is obviously less efficent in terms of Database time for cases where queues are empty. With cursor resetting this is compounded meaning a worker servicing 2 queues can in theory make 4 DB queries and not find any work. To offset this the idea is that with work stealing we can have less replicas for the amplification effect is reduced. In addition we have Leaky Bucket throttling to ensure we don't overwhelm the DB.
2. This could lead to circumstances where higher priorities queues are serviced after lower ones. For example say we have queue "do-now", "do-later" and "do-whenever". We first scan "do-now" and see it as empty so we move onto "do-later". At that point a transaction completes that adds something into "do-now" however jobs in "do-later" and "do-whenever" would be checked / worked before the job in "do-now". To offset this we can rely on fact that not all workers will pick up work at the same time: even if some workers are working lower priority queues others will be finishing work so will start looking at the higher priority queue.