### PR TITLE
Instrument adapter queries for external programs.

### DIFF
--- a/lib/que/adapters/active_record.rb
+++ b/lib/que/adapters/active_record.rb
@@ -13,6 +13,11 @@ module Que
         ::PG::UnableToSend,
       ].freeze
 
+      def initialize(_thing = nil)
+        super
+        @instrumenter = ActiveSupport::Notifications.instrumenter
+      end
+
       def checkout
         checkout_activerecord_adapter { |conn| yield conn.raw_connection }
       rescue *AR_UNAVAILABLE_CONNECTION_ERRORS => e


### PR DESCRIPTION
When executing queries via the adapter, we may not recieve the instrumentation we expect. The ActiveRecord adapter uses a raw connection which bypasses the ActiveRecord instrumentation layer and instead talks directly to PG, making it impossible to know what queries are being executed.

This change cribs heavily from the implementation of the `log` method on the `AbstractAdapter` class in ActiveRecord to make it easy to add instrumentation to an adapter. By default the instrumenter is set to `nil`, and instrumentation will be a no-op; otherwise the query will be instrumented via the `instrument` method and passed the relevant payload to handle. The structure of this is deliberately similar to that of the event emitted by ActiveRecord's `sql.active_record` notification.