### PR TITLE
Add release action for Gem publishing.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Publish gem to GitHub package registry
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: gocardless/github-actions/actions/ruby-bundle-install@master
+        with:
+          known_hosts: ${{ secrets.KNOWN_HOSTS_GITHUB_KEY }}
+          robot_ssh_key: ${{ secrets.ROBOT_READONLY_SSH_KEY }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish Gem
+        uses: gocardless/github-actions/actions/publish-internal-gem@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently we don't release gem versions to our internal package registry, and some codebases even subscribe directly to master on GitHub. This action allows us to publish proper releases as with our other gems, so we can have better management of breaking changes.