### PR TITLE
Lock the rows when taking the advisory lock with ActiveRecordWithLock adapter

### DIFF
--- a/lib/que/middleware/worker_collector.rb
+++ b/lib/que/middleware/worker_collector.rb
@@ -18,6 +18,7 @@ module Que
         register(*WorkerGroup::METRICS)
         register(*Worker::METRICS)
         register(*Locker::METRICS)
+        register(*Adapters::ActiveRecordWithLock::METRICS)
       end
 
       def call(env)

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -184,6 +184,7 @@ module Que
             AND retryable = true
             AND job_id >= $2
             ORDER BY priority, run_at, job_id
+            FOR UPDATE SKIP LOCKED
             LIMIT 1
     },
   }

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -5,24 +5,6 @@ require "que/worker" # required to prevent autoload races
 
 # rubocop:disable RSpec/DescribeClass
 RSpec.describe "multiple workers" do
-  def with_workers(num, stop_timeout: 5, secondary_queues: [], &block)
-    Que::WorkerGroup.start(
-      num,
-      wake_interval: 0.01,
-      secondary_queues: secondary_queues,
-    ).tap(&block).stop(stop_timeout)
-  end
-
-  # Wait for a maximum of [timeout] seconds for all jobs to be worked
-  def wait_for_jobs_to_be_worked(timeout: 10)
-    start = Time.now
-    loop do
-      break if QueJob.count == 0 || Time.now - start > timeout
-
-      sleep 0.1
-    end
-  end
-
   context "with one worker and many jobs" do
     it "works each job exactly once" do
       10.times.each { |i| FakeJob.enqueue(i) }

--- a/spec/lib/que/adapters/active_record_with_lock_spec.rb
+++ b/spec/lib/que/adapters/active_record_with_lock_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Que::Adapters::ActiveRecordWithLock, :active_record_with_lock do
+  subject(:adapter) do
+    described_class.new(job_connection_pool: JobRecord.connection_pool,
+                        lock_connection_pool: LockDatabaseRecord.connection_pool)
+  end
+
+  before do
+    described_class::FindJobHitTotal.values.each { |labels, _| labels.clear }
+  end
+
+  context "with enqueued jobs" do
+    before do
+      10.times do
+        FakeJob.enqueue(1)
+      end
+    end
+
+    it "sets correct metric values" do
+      expect(QueJob.count).to eq(10)
+      with_workers(5) { wait_for_jobs_to_be_worked }
+      expect(QueJob.count).to eq(0)
+      expect(described_class::FindJobHitTotal.values[{ :queue => "default", :job_hit => "true" }]).to eq(10.0)
+    end
+  end
+
+  describe ".lock_job_with_lock_database" do
+    subject(:lock_job) { adapter.lock_job_with_lock_database("default", 0) }
+
+    context "with no jobs enqueued" do
+      it "exists the loop and sets correct metric values" do
+        expect(QueJob.count).to eq(0)
+        locked_job = lock_job
+        expect(locked_job).to eq([])
+        expect(described_class::FindJobHitTotal.values[{ :queue => "default", :job_hit => "true" }]).to eq(0.0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
For ActiveRecordWithLock adapter, we want to lock the rows when acquiring the advisory locks on the table to avoid all the workers trying to lock the same job.

Added metrics to observe the latency to find the job and job hit rate.