### PR TITLE
Remove dead connections from the pool on connection errors.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,7 @@ RSpec/IndexedLet:
 
 RSpec/NestedGroups:
   Max: 5
+
+Sequel/IrreversibleMigration:
+  Exclude:
+    - "**/*_spec.rb"


### PR DESCRIPTION
With the introduction of Yugabyte, there is now the possibility that connections in the pool may become "dead" when new nodes are rotated into a cluster, since they end up pointing at a node which no longer exists. In this case, we can proactively remove these connections from the connection pool when we see the corresponding exceptions.

As long as jobs are retryable the work will still eventually be processed - this merely prevents us from being stuck in a pathological case where the pool contains dead connections and nothing is automatically clearing them out (e.g. a deployment killing the pod).