### PR TITLE
Switch from WEBrick to Puma

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version: ["3.0", "3.1", "3.2", "3.3"]
-        rack_version: ["~> 2", "~> 3"]
+        rack_version: ["2.2", "3.1"]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -46,6 +46,7 @@ jobs:
       PGPASSWORD: password
       PGHOST: localhost
       BUNDLE_RUBYGEMS__PKG__GITHUB__COM: gocardless-robot-readonly:${{ secrets.GITHUB_TOKEN }}
+      RACK_VERSION: "${{ matrix.rack_version }}"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
@@ -53,14 +54,6 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: "${{ matrix.ruby_version }}"
-      - name: Update Gemfile for Rack and Rackup versions
-        run: |
-          if [[ "${{ matrix.rack_version }}" == "~> 2" ]]; then
-            echo 'gem "rackup", "~> 1"' >> Gemfile
-          fi
-          echo 'gem "rack", "${{ matrix.rack_version }}"' >> Gemfile
-      - name: Install Dependencies
-        run: bundle install
       - name: Start bin/que
         run: |
           bundle exec bin/que ./lib/que.rb --metrics-port=8080 --ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version: ["3.0", "3.1", "3.2", "3.3"]
-        rack_version: ["2.2", "3.1"]
+        rack_version: ["2.2.5", "3.1"]
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version: ["3.0", "3.1", "3.2", "3.3"]
+        rack_version: ["~> 2", "~> 3"]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -51,7 +52,15 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "${{ matrix.ruby-version }}"
+          ruby-version: "${{ matrix.ruby_version }}"
+      - name: Update Gemfile for Rack and Rackup versions
+        run: |
+          if [[ "${{ matrix.rack_version }}" == "~> 2" ]]; then
+            echo 'gem "rackup", "~> 1"' >> Gemfile
+          fi
+          echo 'gem "rack", "${{ matrix.rack_version }}"' >> Gemfile
+      - name: Install Dependencies
+        run: bundle install
       - name: Start bin/que
         run: |
           bundle exec bin/que ./lib/que.rb --metrics-port=8080 --ci

--- a/Gemfile
+++ b/Gemfile
@@ -17,20 +17,20 @@ group :development, :test do
   gem 'rubocop-rspec', '~> 3.0.2'
   gem 'rubocop-sequel', '~> 0.3.4'
   gem 'sequel', require: nil
+
+  rack_version = ENV.fetch('RACK_VERSION', "3.1")
+  gem "rack", rack_version
+  if Gem::Version.new(rack_version) < Gem::Version.new('3.0.0')
+    gem "rackup", "~> 1.0"
+  else
+    gem "rackup", "~> 2.0"
+  end
 end
 
 group :test do
   gem 'pry'
   gem 'pry-byebug'
   gem 'rspec', '~> 3.9'
-end
-
-rack_version = ENV['RACK_VERSION'] || "3.0"
-gem "rack", rack_version
-if Gem::Version.new(rack_version) < Gem::Version.new('3.0.0')
-  gem "rackup", "~> 1.0"
-else
-  gem "rackup", "~> 2.0"
 end
 
 gem 'prometheus-client', '~> 1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,14 @@ group :test do
   gem 'rspec', '~> 3.9'
 end
 
+rack_version = ENV['RACK_VERSION'] || "3.0"
+gem "rack", rack_version
+if Gem::Version.new(rack_version) < Gem::Version.new('3.0.0')
+  gem "rackup", "~> 1.0"
+else
+  gem "rackup", "~> 2.0"
+end
+
 gem 'prometheus-client', '~> 1.0'
 source "https://rubygems.pkg.github.com/gocardless" do
   gem "prometheus_gcstat"

--- a/bin/que
+++ b/bin/que
@@ -9,6 +9,11 @@ require "prometheus_gcstat"
 require "puma"
 require "que"
 require "rack"
+USE_RACKUP = Rack.release.split(".")[0].to_i >= 3
+if USE_RACKUP
+  require "rackup"
+end
+require "rack/handler/puma"
 
 $stdout.sync = true
 
@@ -172,7 +177,14 @@ if options.metrics_port
 
     host = "0.0.0.0"
 
-    Rack::Handler::Puma.run(
+    handler =
+      if USE_RACKUP
+        Rackup::Handler::Puma
+      else
+        Rack::Handler::Puma
+      end
+
+    handler.run(
       app,
       Host: host,
       Port: options.metrics_port,

--- a/bin/que
+++ b/bin/que
@@ -4,16 +4,11 @@
 require "logger"
 require "optparse"
 require "ostruct"
-require "que"
-require "rack"
 require "prometheus/middleware/exporter"
 require "prometheus_gcstat"
-require "webrick"
-
-if Rack.release[0] == "3"
-  # Required if using Rack 3.x
-  require "rackup"
-end
+require "puma"
+require "que"
+require "rack"
 
 $stdout.sync = true
 
@@ -176,25 +171,14 @@ if options.metrics_port
     )
 
     host = "0.0.0.0"
-    logger = WEBrick::Log.new("/dev/null")
 
-    if Rack.release[0] == "3"
-      Rackup::Handler::WEBrick.run(
-        app,
-        Host: host,
-        Port: options.metrics_port,
-        Logger: logger,
-        AccessLog: [],
-      )
-    else
-      Rack::Handler::WEBrick.run(
-        app,
-        Host: host,
-        Port: options.metrics_port,
-        Logger: logger,
-        AccessLog: [],
-      )
-    end
+    Rack::Handler::Puma.run(
+      app,
+      Host: host,
+      Port: options.metrics_port,
+      Silent: false,
+      AccessLog: [],
+    )
   end
 end
 

--- a/que.gemspec
+++ b/que.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "puma"
   spec.add_dependency "rack", ">= 2", "< 4"
+  spec.add_dependency "rackup"
 
   spec.add_runtime_dependency "activesupport"
   spec.metadata["rubygems_mfa_required"] = "true"

--- a/que.gemspec
+++ b/que.gemspec
@@ -27,9 +27,8 @@ Gem::Specification.new do |spec|
   # This is highly non ideal, but unless we properly fork, we have to do this for now.
   spec.add_dependency "prometheus-client"
 
+  spec.add_dependency "puma"
   spec.add_dependency "rack", ">= 2", "< 4"
-  spec.add_dependency "rackup"
-  spec.add_dependency "webrick"
 
   spec.add_runtime_dependency "activesupport"
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
WEBrick appears to be approaching EOL and is being removed from Rackup, as mentioned [here](https://github.com/rack/rackup/blob/main/readme.md#soft-deprecation). This is causing issues with a number of services as discussed [here](https://gocardless.slack.com/archives/C6ZKC4F4L/p1730735504149619). By switching to Puma we can solve this issue while also still supporting both Rack 2 and 3.