### PR TITLE
Switch from WEBrick to Puma

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version: ["3.0", "3.1", "3.2", "3.3"]
+        rack_version: ["2.2.5", "3.1"]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -45,13 +46,14 @@ jobs:
       PGPASSWORD: password
       PGHOST: localhost
       BUNDLE_RUBYGEMS__PKG__GITHUB__COM: gocardless-robot-readonly:${{ secrets.GITHUB_TOKEN }}
+      RACK_VERSION: "${{ matrix.rack_version }}"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "${{ matrix.ruby-version }}"
+          ruby-version: "${{ matrix.ruby_version }}"
       - name: Start bin/que
         run: |
           bundle exec bin/que ./lib/que.rb --metrics-port=8080 --ci

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,14 @@ group :development, :test do
   gem 'rubocop-rspec', '~> 3.0.2'
   gem 'rubocop-sequel', '~> 0.3.4'
   gem 'sequel', require: nil
+
+  rack_version = ENV.fetch('RACK_VERSION', "3.1")
+  gem "rack", rack_version
+  if Gem::Version.new(rack_version) < Gem::Version.new('3.0.0')
+    gem "rackup", "~> 1.0"
+  else
+    gem "rackup", "~> 2.0"
+  end
 end
 
 group :test do

--- a/bin/que
+++ b/bin/que
@@ -184,12 +184,15 @@ if options.metrics_port
         Rack::Handler::Puma
       end
 
+    pidfile_opts = Dir.exist?("./tmp/pids/") ? {} : { pidfile: nil }
+
     handler.run(
       app,
       Host: host,
       Port: options.metrics_port,
       Silent: false,
       AccessLog: [],
+      **pidfile_opts,
     )
   end
 end

--- a/bin/que
+++ b/bin/que
@@ -4,16 +4,16 @@
 require "logger"
 require "optparse"
 require "ostruct"
-require "que"
-require "rack"
 require "prometheus/middleware/exporter"
 require "prometheus_gcstat"
-require "webrick"
-
-if Rack.release[0] == "3"
-  # Required if using Rack 3.x
+require "puma"
+require "que"
+require "rack"
+USE_RACKUP = Rack.release.split(".")[0].to_i >= 3
+if USE_RACKUP
   require "rackup"
 end
+require "rack/handler/puma"
 
 $stdout.sync = true
 
@@ -176,25 +176,21 @@ if options.metrics_port
     )
 
     host = "0.0.0.0"
-    logger = WEBrick::Log.new("/dev/null")
 
-    if Rack.release[0] == "3"
-      Rackup::Handler::WEBrick.run(
-        app,
-        Host: host,
-        Port: options.metrics_port,
-        Logger: logger,
-        AccessLog: [],
-      )
-    else
-      Rack::Handler::WEBrick.run(
-        app,
-        Host: host,
-        Port: options.metrics_port,
-        Logger: logger,
-        AccessLog: [],
-      )
-    end
+    handler =
+      if USE_RACKUP
+        Rackup::Handler::Puma
+      else
+        Rack::Handler::Puma
+      end
+
+    handler.run(
+      app,
+      Host: host,
+      Port: options.metrics_port,
+      Silent: false,
+      AccessLog: [],
+    )
   end
 end
 

--- a/que.gemspec
+++ b/que.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   # This is highly non ideal, but unless we properly fork, we have to do this for now.
   spec.add_dependency "prometheus-client"
 
+  spec.add_dependency "puma"
   spec.add_dependency "rack", ">= 2", "< 4"
   spec.add_dependency "rackup"
-  spec.add_dependency "webrick"
 
   spec.add_runtime_dependency "activesupport"
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
WEBrick appears to be approaching EOL and is being removed from Rackup, as mentioned [here](https://github.com/rack/rackup/blob/main/readme.md#soft-deprecation). This is causing issues with a number of services as discussed [here](https://gocardless.slack.com/archives/C6ZKC4F4L/p1730735504149619). By switching to Puma we can solve this issue while also still supporting both Rack 2 and 3.

I merged this change in a [previous PR](https://github.com/gocardless/que/pull/112), but [then had to revert it](https://github.com/gocardless/que/pull/113) due to [issues in pay-svc](https://gocardless.slack.com/archives/C01JMFWJW2Z/p1732024205915709). This PR adds a fix (the second commit) to pass in `pidfile: nil` to Puma if `tmp/pids/` doesn't exist. I'll test this out on Skyhook and Pay-svc for a few days to get confidence it works okay.