### PR TITLE
IX-1782: Que health check surfaces unhealthy state if postgres_error on any worker

### DIFF
--- a/bin/que
+++ b/bin/que
@@ -138,7 +138,7 @@ if options.metrics_port
       port: options.metrics_port,
     )
 
-    health_check = ->(_) { [200, {}, ["healthy"]] }
+    health_check = Que::Middleware::WorkerHealthCheck.new(worker_group)
 
     if defined?(Prometheus::MemoryStats)
       Prometheus::MemoryStats.

--- a/lib/que.rb
+++ b/lib/que.rb
@@ -14,6 +14,7 @@ require_relative "que/worker"
 require_relative "que/worker_group"
 require_relative "que/middleware/worker_collector"
 require_relative "que/middleware/queue_collector"
+require_relative "que/middleware/worker_health_check"
 
 module Que
   begin

--- a/lib/que/middleware/worker_health_check.rb
+++ b/lib/que/middleware/worker_health_check.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Que
+  module Middleware
+    # Rack application that reflects the health of all workers in the worker
+    # group. Returns 503 if all workers have encountered a postgres error on
+    # their last work cycle, 200 otherwise.
+    #
+    # A single worker in postgres_error state may be transient; only when all
+    # workers are unhealthy is the pod restarted with fresh database connections.
+    class WorkerHealthCheck
+      def initialize(worker_group)
+        @worker_group = worker_group
+      end
+
+      def call(_env)
+        workers = @worker_group.workers
+        if workers.empty? || workers.any?(&:healthy?)
+          [200, { "Content-Type" => "text/plain" }, ["healthy"]]
+        else
+          [503, { "Content-Type" => "text/plain" }, ["unhealthy"]]
+        end
+      end
+    end
+  end
+end

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -129,6 +129,7 @@ module Que
       @stop = false # instruct worker to stop
       @stopped = false # mark worker as having stopped
       @current_running_job = nil
+      @last_work_result = nil
       @locker = Locker.new(
         queue: queue,
         cursor_expiry: lock_cursor_expiry,
@@ -170,7 +171,7 @@ module Que
     def work
       Que.adapter.checkout do
         @locker.with_locked_job do |job|
-          return :job_not_found if job.nil?
+          return (@last_work_result = :job_not_found) if job.nil?
 
           log_keys = {
             priority: job["priority"],
@@ -258,13 +259,13 @@ module Que
               handle_job_failure(e, job)
             end
           end
-          :job_worked
+          @last_work_result = :job_worked
         end
       end
     rescue PG::Error, Adapters::UnavailableConnection => _e
       # In the event that our Postgres connection is bad, we don't want that error to halt
       # the work loop. Instead, we should let the work loop sleep and retry.
-      :postgres_error
+      @last_work_result = :postgres_error
     end
 
     # rubocop:enable Metrics/MethodLength
@@ -275,6 +276,10 @@ module Que
 
     def stopped?
       @stopped
+    end
+
+    def healthy?
+      @last_work_result != :postgres_error
     end
 
     def collect_metrics

--- a/spec/lib/que/middleware/worker_health_check_spec.rb
+++ b/spec/lib/que/middleware/worker_health_check_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Que::Middleware::WorkerHealthCheck do
+  subject(:health_check) { described_class.new(worker_group) }
+
+  let(:worker_group) { instance_double(Que::WorkerGroup, workers: workers) }
+
+  describe "#call" do
+    context "when all workers are healthy" do
+      let(:workers) do
+        [
+          instance_double(Que::Worker, healthy?: true),
+          instance_double(Que::Worker, healthy?: true),
+        ]
+      end
+
+      it "returns 200 with a healthy body" do
+        status, _, body = health_check.call({})
+        expect(status).to eq(200)
+        expect(body).to eq(["healthy"])
+      end
+    end
+
+    context "when one worker is in a postgres_error state" do
+      let(:workers) do
+        [
+          instance_double(Que::Worker, healthy?: true),
+          instance_double(Que::Worker, healthy?: false),
+        ]
+      end
+
+      it "returns 200" do
+        status, = health_check.call({})
+        expect(status).to eq(200)
+      end
+    end
+
+    context "when all workers are in a postgres_error state" do
+      let(:workers) do
+        [
+          instance_double(Que::Worker, healthy?: false),
+          instance_double(Que::Worker, healthy?: false),
+        ]
+      end
+
+      it "returns 503 with an unhealthy body" do
+        status, _, body = health_check.call({})
+        expect(status).to eq(503)
+        expect(body).to eq(["unhealthy"])
+      end
+    end
+
+    context "when there are no workers" do
+      let(:workers) { [] }
+
+      it "returns 200" do
+        status, = health_check.call({})
+        expect(status).to eq(200)
+      end
+    end
+  end
+end

--- a/spec/lib/que/worker_spec.rb
+++ b/spec/lib/que/worker_spec.rb
@@ -264,4 +264,42 @@ RSpec.describe Que::Worker do
       end
     end
   end
+
+  describe "#healthy?" do
+    subject(:worker) { described_class.new }
+
+    it "is true before the worker has done any work" do
+      expect(worker).to be_healthy
+    end
+
+    it "is true when no job is found" do
+      worker.work
+      expect(worker).to be_healthy
+    end
+
+    it "is true after successfully working a job" do
+      FakeJob.enqueue(1)
+      worker.work
+      expect(worker).to be_healthy
+    end
+
+    it "is false after a postgres error" do
+      FakeJob.enqueue(1)
+      expect(Que).
+        to receive(:execute).with(:lock_job, ["default", 0]).and_raise(PG::Error)
+      worker.work
+      expect(worker).to_not be_healthy
+    end
+
+    it "recovers once work succeeds after a postgres error" do
+      expect(Que).
+        to receive(:execute).with(:lock_job, ["default", 0]).and_raise(PG::Error)
+      worker.work
+      expect(worker).to_not be_healthy
+
+      allow(Que).to receive(:execute).with(:lock_job, ["default", 0]).and_return([])
+      worker.work # no job found, returns :job_not_found
+      expect(worker).to be_healthy
+    end
+  end
 end

--- a/spec/smoke_tests/worker_health_check_spec.rb
+++ b/spec/smoke_tests/worker_health_check_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "English"
+require "net/http"
+
+RSpec.describe "Worker health check", :smoke_test do # rubocop:disable RSpec/DescribeClass
+  # Use a short wake interval so workers complete at least one cycle before we
+  # probe, without having to wait the default 5 seconds.
+  let(:wake_interval) { 0.1 }
+  let(:metrics_port) { 8081 }
+
+  def spawn_que(task_file)
+    Process.spawn(
+      "bundle exec bin/que #{task_file} " \
+      "--metrics-port=#{metrics_port} " \
+      "--wake-interval=#{wake_interval}",
+    )
+  end
+
+  def health_check_response
+    Net::HTTP.get_response(URI("http://0.0.0.0:#{metrics_port}/"))
+  end
+
+  context "when workers are healthy" do
+    it "returns 200" do
+      pid = spawn_que("./tasks/smoke_test.rb")
+      sleep 3
+
+      response = health_check_response
+
+      expect(response.code).to eq("200")
+      expect(response.body).to eq("healthy")
+    ensure
+      Process.kill("INT", pid)
+      Process.wait(pid)
+    end
+  end
+
+  context "when workers have a persistent postgres error" do
+    it "returns 503" do
+      pid = spawn_que("./tasks/smoke_test_unhealthy.rb")
+      sleep 3
+
+      response = health_check_response
+
+      expect(response.code).to eq("503")
+      expect(response.body).to eq("unhealthy")
+    ensure
+      Process.kill("INT", pid)
+      Process.wait(pid)
+    end
+  end
+end

--- a/tasks/smoke_test_unhealthy.rb
+++ b/tasks/smoke_test_unhealthy.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "active_record"
+require_relative "../lib/que"
+
+ActiveRecord::Base.establish_connection(
+  adapter: "postgresql",
+  host: ENV.fetch("PGHOST", "localhost"),
+  user: ENV.fetch("PGUSER", "postgres"),
+  password: ENV.fetch("PGPASSWORD", ""),
+  database: ENV.fetch("PGDATABASE", "que-test"),
+)
+
+Que.connection = ActiveRecord
+Que.migrate!
+
+# Replace the adapter so every work attempt raises PG::Error, simulating a
+# persistent bad connection. Workers will always return :postgres_error,
+# so the health check should always return 503.
+class AlwaysFailingAdapter < Que::Adapters::Base
+  def checkout
+    raise PG::Error, "simulated persistent postgres error"
+  end
+end
+
+Que.adapter = AlwaysFailingAdapter.new


### PR DESCRIPTION
During a recent incident, after a CloudSQL maintenance event, Que worker pods can end up in a stale database connection state. Workers handle this internally - on a `PG::Error`, they return `:postgres_error`, sleep for the wake interval, and retry. The health check is a hardcoded lambda that always returns 200. Hence, Kubernetes also has no signal to restart the affected pods, and the worker in the incident ended up perpetually retrying a faulty connection every 5 seconds.

Let's track the result of each work cycle on the workers itself and expose it through a `healthy?` predicate (which purely checks whether the worker is in a `postgres_error` state on its last `work_loop` cycle). The health check endpoint now delegates to a new `WorkerHealthCheck` that checks every worker in the group and returns 503 if any of them are in a unhealthy state, otherwise returns the 200 it has always been returning. 

Yes, this health check now can return a non-200 and this is the only 'breaking' change, but should mean Kubernetes has a signal to restart pods when liveness probe threshold gets breached.