### PR TITLE
Add optional cursor for `run_at` time on jobs

### DIFF
--- a/bin/que
+++ b/bin/que
@@ -47,7 +47,7 @@ OptionParser.new do |opts|
     options.lock_budget = lock_budget
   end
 
-  opts.on("--run-at-cursor", "Enable run_at cursor to skip jobs scheduled before the previous job's run_at (default: false)") do
+  opts.on("--run-at-cursor", "Enable run_at cursor to skip jobs due before the previous job's run_at (default: false)") do
     options.run_at_cursor = true
   end
 

--- a/bin/que
+++ b/bin/que
@@ -47,6 +47,10 @@ OptionParser.new do |opts|
     options.lock_budget = lock_budget
   end
 
+  opts.on("--run-at-cursor", "Enable run_at cursor to skip jobs scheduled before the previous job's run_at (default: false)") do
+    options.run_at_cursor = true
+  end
+
   opts.on("-c", "--worker-count [COUNT]", Integer, "Start this many threaded workers") do |worker_count|
     options.worker_count = worker_count
   end
@@ -100,6 +104,7 @@ log_level        = options.log_level     || ENV["QUE_LOG_LEVEL"]           || "i
 queue_name       = options.queue_name    || ENV["QUE_QUEUE"]               || Que::Worker::DEFAULT_QUEUE
 wake_interval    = options.wake_interval || ENV["QUE_WAKE_INTERVAL"]&.to_f || Que::Worker::DEFAULT_WAKE_INTERVAL
 cursor_expiry    = options.cursor_expiry || wake_interval
+run_at_cursor    = options.run_at_cursor || false
 worker_count     = options.worker_count  || 1
 timeout          = options.timeout
 secondary_queues = options.secondary_queues || []
@@ -128,6 +133,7 @@ worker_group = Que::WorkerGroup.start(
   lock_window: options.lock_window,
   lock_budget: options.lock_budget,
   secondary_queues: secondary_queues,
+  run_at_cursor: run_at_cursor,
 )
 
 if options.metrics_port

--- a/lib/que/adapters/active_record_with_lock.rb
+++ b/lib/que/adapters/active_record_with_lock.rb
@@ -48,7 +48,7 @@ module Que
 
       # This method continues looping through the que_jobs table until it either
       # locks a job successfully or determines that there are no jobs to process.
-      def lock_job_with_lock_database(queue, cursor, run_at_cursor = '-infinity')
+      def lock_job_with_lock_database(queue, cursor, run_at_cursor = Que::Locker::RUN_AT_CURSOR_RESET)
         loop do
           observe(duration_metric: FindJobSecondsTotal, labels: { queue: queue }) do
             Que.transaction do

--- a/lib/que/adapters/active_record_with_lock.rb
+++ b/lib/que/adapters/active_record_with_lock.rb
@@ -36,8 +36,8 @@ module Que
       def execute(command, params = [])
         case command
         when :lock_job
-          queue, cursor, run_at_cursor = params
-          lock_job_with_lock_database(queue, cursor, run_at_cursor)
+          queue, cursor, run_at_lower_bound = params
+          lock_job_with_lock_database(queue, cursor, run_at_lower_bound)
         when :unlock_job
           job_id = params[0]
           unlock_job(job_id)
@@ -48,11 +48,11 @@ module Que
 
       # This method continues looping through the que_jobs table until it either
       # locks a job successfully or determines that there are no jobs to process.
-      def lock_job_with_lock_database(queue, cursor, run_at_cursor = Que::Locker::RUN_AT_CURSOR_RESET)
+      def lock_job_with_lock_database(queue, cursor, run_at_lower_bound = Que::Locker::RUN_AT_CURSOR_RESET)
         loop do
           observe(duration_metric: FindJobSecondsTotal, labels: { queue: queue }) do
             Que.transaction do
-              job_to_lock = Que.execute(:find_job_to_lock, [queue, cursor, run_at_cursor])
+              job_to_lock = Que.execute(:find_job_to_lock, [queue, cursor, run_at_lower_bound])
               return job_to_lock if job_to_lock.empty?
 
               cursor = job_to_lock.first["job_id"]

--- a/lib/que/adapters/active_record_with_lock.rb
+++ b/lib/que/adapters/active_record_with_lock.rb
@@ -36,8 +36,8 @@ module Que
       def execute(command, params = [])
         case command
         when :lock_job
-          queue, cursor = params
-          lock_job_with_lock_database(queue, cursor)
+          queue, cursor, run_at_cursor = params
+          lock_job_with_lock_database(queue, cursor, run_at_cursor)
         when :unlock_job
           job_id = params[0]
           unlock_job(job_id)
@@ -48,11 +48,11 @@ module Que
 
       # This method continues looping through the que_jobs table until it either
       # locks a job successfully or determines that there are no jobs to process.
-      def lock_job_with_lock_database(queue, cursor)
+      def lock_job_with_lock_database(queue, cursor, run_at_cursor = '-infinity')
         loop do
           observe(duration_metric: FindJobSecondsTotal, labels: { queue: queue }) do
             Que.transaction do
-              job_to_lock = Que.execute(:find_job_to_lock, [queue, cursor])
+              job_to_lock = Que.execute(:find_job_to_lock, [queue, cursor, run_at_cursor])
               return job_to_lock if job_to_lock.empty?
 
               cursor = job_to_lock.first["job_id"]

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -15,7 +15,7 @@ module Que
   # For more information, see the 'Predicate Specificity' chapter of:
   # https://brandur.org/postgres-queues
   class Locker
-    RUN_AT_CURSOR_RESET = RUN_AT_CURSOR_RESET
+    RUN_AT_CURSOR_RESET = "-infinity"
 
     METRICS = [
       ExistsTotal = Prometheus::Client::Counter.new(

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -60,7 +60,7 @@ module Que
       @cursor_expiry = cursor_expiry
       @run_at_cursor = run_at_cursor
       @queue_cursors = {}
-      @queue_run_at_cursors = {}
+      @run_at_lower_bounds = {}
       @queue_expires_at = {}
       @secondary_queues = secondary_queues
       @consolidated_queues = Array.wrap(queue).concat(secondary_queues)
@@ -82,8 +82,8 @@ module Que
 
       job = @consolidated_queues.lazy.filter_map do |queue|
         cursor = @queue_cursors.fetch(queue, 0)
-        run_at_cursor = @queue_run_at_cursors.fetch(queue, RUN_AT_CURSOR_RESET)
-        found_job = lock_job_in(queue, cursor, run_at_cursor)
+        run_at_lower_bound = @run_at_lower_bounds.fetch(queue, RUN_AT_CURSOR_RESET)
+        found_job = lock_job_in(queue, cursor, run_at_lower_bound)
 
         # Because we were using a cursor when we tried to lock this job, if we fail to
         # find a job it is not necessarily the case that there aren't jobs in the
@@ -121,7 +121,7 @@ module Que
       return if job && !exists?(job)
 
       @queue_cursors[job[:queue]] = job[:job_id] if job
-      @queue_run_at_cursors[job[:queue]] = job[:run_at] if job && @run_at_cursor
+      @run_at_lower_bounds[job[:queue]] = job[:run_at] if job && @run_at_cursor
 
       yield job
     ensure
@@ -134,17 +134,17 @@ module Que
 
     private
 
-    def lock_job_in(queue, cursor, run_at_cursor)
+    def lock_job_in(queue, cursor, run_at_lower_bound)
       observe(nil, ThrottleSecondsTotal, worked_queue: queue) { @leaky_bucket.refill }
-      @leaky_bucket.observe { execute_lock_job_in(queue, cursor, run_at_cursor) }
+      @leaky_bucket.observe { execute_lock_job_in(queue, cursor, run_at_lower_bound) }
     end
 
-    def execute_lock_job_in(queue, cursor, run_at_cursor)
+    def execute_lock_job_in(queue, cursor, run_at_lower_bound)
       strategy = cursor.zero? ? "full" : "cursor"
       observe(AcquireTotal, AcquireSecondsTotal,
               worked_queue: queue,
               strategy: strategy) do
-        lock_job_query(queue, cursor, run_at_cursor)
+        lock_job_query(queue, cursor, run_at_lower_bound)
       end
     end
 
@@ -154,8 +154,8 @@ module Que
       end
     end
 
-    def lock_job_query(queue, cursor, run_at_cursor)
-      Que.execute(:lock_job, [queue, cursor, run_at_cursor]).first
+    def lock_job_query(queue, cursor, run_at_lower_bound)
+      Que.execute(:lock_job, [queue, cursor, run_at_lower_bound]).first
     end
 
     def handle_expired_cursors!
@@ -167,7 +167,7 @@ module Que
 
     def reset_cursor_for!(queue)
       @queue_cursors[queue] = 0
-      @queue_run_at_cursors[queue] = RUN_AT_CURSOR_RESET
+      @run_at_lower_bounds[queue] = RUN_AT_CURSOR_RESET
       @queue_expires_at[queue] = monotonic_now + @cursor_expiry
     end
 

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -80,7 +80,8 @@ module Que
 
       job = @consolidated_queues.lazy.filter_map do |queue|
         cursor = @queue_cursors.fetch(queue, 0)
-        found_job = lock_job_in(queue, cursor)
+        run_at_cursor = @queue_run_at_cursors.fetch(queue, '-infinity')
+        found_job = lock_job_in(queue, cursor, run_at_cursor)
 
         # Because we were using a cursor when we tried to lock this job, if we fail to
         # find a job it is not necessarily the case that there aren't jobs in the
@@ -96,7 +97,7 @@ module Que
         # do the appropriate book keeping.
         if found_job.nil? && cursor != 0
           reset_cursor_for!(queue)
-          found_job = lock_job_in(queue, 0)
+          found_job = lock_job_in(queue, 0, '-infinity')
         end
 
         found_job
@@ -131,17 +132,17 @@ module Que
 
     private
 
-    def lock_job_in(queue, cursor)
+    def lock_job_in(queue, cursor, run_at_cursor)
       observe(nil, ThrottleSecondsTotal, worked_queue: queue) { @leaky_bucket.refill }
-      @leaky_bucket.observe { execute_lock_job_in(queue, cursor) }
+      @leaky_bucket.observe { execute_lock_job_in(queue, cursor, run_at_cursor) }
     end
 
-    def execute_lock_job_in(queue, cursor)
+    def execute_lock_job_in(queue, cursor, run_at_cursor)
       strategy = cursor.zero? ? "full" : "cursor"
       observe(AcquireTotal, AcquireSecondsTotal,
               worked_queue: queue,
               strategy: strategy) do
-        lock_job_query(queue, cursor)
+        lock_job_query(queue, cursor, run_at_cursor)
       end
     end
 
@@ -151,9 +152,8 @@ module Que
       end
     end
 
-    def lock_job_query(queue, cursor)
-      run_at = @queue_run_at_cursors.fetch(queue, '-infinity')
-      Que.execute(:lock_job, [queue, cursor, run_at]).first
+    def lock_job_query(queue, cursor, run_at_cursor)
+      Que.execute(:lock_job, [queue, cursor, run_at_cursor]).first
     end
 
     def handle_expired_cursors!

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -53,10 +53,12 @@ module Que
       ),
     ].freeze
 
-    def initialize(queue:, cursor_expiry:, window: nil, budget: nil, secondary_queues: [])
+    def initialize(queue:, cursor_expiry:, window: nil, budget: nil, secondary_queues: [], run_at_cursor: false)
       @queue = queue
       @cursor_expiry = cursor_expiry
+      @run_at_cursor = run_at_cursor
       @queue_cursors = {}
+      @queue_run_at_cursors = {}
       @queue_expires_at = {}
       @secondary_queues = secondary_queues
       @consolidated_queues = Array.wrap(queue).concat(secondary_queues)
@@ -116,6 +118,7 @@ module Que
       return if job && !exists?(job)
 
       @queue_cursors[job[:queue]] = job[:job_id] if job
+      @queue_run_at_cursors[job[:queue]] = job[:run_at] if job && @run_at_cursor
 
       yield job
     ensure
@@ -149,7 +152,8 @@ module Que
     end
 
     def lock_job_query(queue, cursor)
-      Que.execute(:lock_job, [queue, cursor]).first
+      run_at = @queue_run_at_cursors.fetch(queue, '-infinity')
+      Que.execute(:lock_job, [queue, cursor, run_at]).first
     end
 
     def handle_expired_cursors!
@@ -161,6 +165,7 @@ module Que
 
     def reset_cursor_for!(queue)
       @queue_cursors[queue] = 0
+      @queue_run_at_cursors[queue] = '-infinity'
       @queue_expires_at[queue] = monotonic_now + @cursor_expiry
     end
 

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -15,7 +15,7 @@ module Que
   # For more information, see the 'Predicate Specificity' chapter of:
   # https://brandur.org/postgres-queues
   class Locker
-    RUN_AT_CURSOR_RESET = "-infinity"
+    RUN_AT_CURSOR_RESET = nil
 
     METRICS = [
       ExistsTotal = Prometheus::Client::Counter.new(

--- a/lib/que/locker.rb
+++ b/lib/que/locker.rb
@@ -15,6 +15,8 @@ module Que
   # For more information, see the 'Predicate Specificity' chapter of:
   # https://brandur.org/postgres-queues
   class Locker
+    RUN_AT_CURSOR_RESET = RUN_AT_CURSOR_RESET
+
     METRICS = [
       ExistsTotal = Prometheus::Client::Counter.new(
         :que_locker_exists_total,
@@ -80,7 +82,7 @@ module Que
 
       job = @consolidated_queues.lazy.filter_map do |queue|
         cursor = @queue_cursors.fetch(queue, 0)
-        run_at_cursor = @queue_run_at_cursors.fetch(queue, '-infinity')
+        run_at_cursor = @queue_run_at_cursors.fetch(queue, RUN_AT_CURSOR_RESET)
         found_job = lock_job_in(queue, cursor, run_at_cursor)
 
         # Because we were using a cursor when we tried to lock this job, if we fail to
@@ -97,7 +99,7 @@ module Que
         # do the appropriate book keeping.
         if found_job.nil? && cursor != 0
           reset_cursor_for!(queue)
-          found_job = lock_job_in(queue, 0, '-infinity')
+          found_job = lock_job_in(queue, 0, RUN_AT_CURSOR_RESET)
         end
 
         found_job
@@ -165,7 +167,7 @@ module Que
 
     def reset_cursor_for!(queue)
       @queue_cursors[queue] = 0
-      @queue_run_at_cursors[queue] = '-infinity'
+      @queue_run_at_cursors[queue] = RUN_AT_CURSOR_RESET
       @queue_expires_at[queue] = monotonic_now + @cursor_expiry
     end
 

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -53,6 +53,7 @@ module Que
           FROM que_jobs AS j
           WHERE queue = $1::text
           AND job_id >= $2
+          AND run_at >= $3::timestamptz
           AND run_at <= now()
           AND retryable = true
           ORDER BY priority, run_at, job_id
@@ -65,6 +66,7 @@ module Que
               SELECT j
               FROM que_jobs AS j
               WHERE queue = $1::text
+              AND run_at >= $3::timestamptz
               AND run_at <= now()
               AND retryable = true
               AND (priority, run_at, job_id) > (jobs.priority, jobs.run_at, jobs.job_id)
@@ -183,6 +185,7 @@ module Que
             AND run_at <= now()
             AND retryable = true
             AND job_id >= $2
+            AND run_at >= $3::timestamptz
             ORDER BY priority, run_at, job_id
             FOR UPDATE SKIP LOCKED
             LIMIT 1

--- a/lib/que/sql.rb
+++ b/lib/que/sql.rb
@@ -53,7 +53,7 @@ module Que
           FROM que_jobs AS j
           WHERE queue = $1::text
           AND job_id >= $2
-          AND run_at >= $3::timestamptz
+          AND run_at >= COALESCE($3::timestamptz, '-infinity'::timestamptz)
           AND run_at <= now()
           AND retryable = true
           ORDER BY priority, run_at, job_id
@@ -66,7 +66,7 @@ module Que
               SELECT j
               FROM que_jobs AS j
               WHERE queue = $1::text
-              AND run_at >= $3::timestamptz
+              AND run_at >= COALESCE($3::timestamptz, '-infinity'::timestamptz)
               AND run_at <= now()
               AND retryable = true
               AND (priority, run_at, job_id) > (jobs.priority, jobs.run_at, jobs.job_id)
@@ -185,7 +185,7 @@ module Que
             AND run_at <= now()
             AND retryable = true
             AND job_id >= $2
-            AND run_at >= $3::timestamptz
+            AND run_at >= COALESCE($3::timestamptz, '-infinity'::timestamptz)
             ORDER BY priority, run_at, job_id
             FOR UPDATE SKIP LOCKED
             LIMIT 1

--- a/lib/que/worker.rb
+++ b/lib/que/worker.rb
@@ -121,7 +121,8 @@ module Que
       lock_cursor_expiry: DEFAULT_WAKE_INTERVAL,
       lock_window: nil,
       lock_budget: nil,
-      secondary_queues: []
+      secondary_queues: [],
+      run_at_cursor: false
     )
       @queue = queue
       @wake_interval = wake_interval
@@ -136,6 +137,7 @@ module Que
         window: lock_window,
         budget: lock_budget,
         secondary_queues: secondary_queues,
+        run_at_cursor: run_at_cursor,
       )
     end
 

--- a/spec/lib/que/adapters/active_record_with_lock_spec.rb
+++ b/spec/lib/que/adapters/active_record_with_lock_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Que::Adapters::ActiveRecordWithLock, :active_record_with_lock do
   end
 
   describe ".lock_job_with_lock_database" do
-    subject(:lock_job) { adapter.lock_job_with_lock_database("default", 0) }
+    subject(:lock_job) { adapter.lock_job_with_lock_database("default", 0, '-infinity') }
 
     context "with no jobs enqueued" do
       it "exists the loop and sets correct metric values" do
@@ -38,6 +38,15 @@ RSpec.describe Que::Adapters::ActiveRecordWithLock, :active_record_with_lock do
         locked_job = lock_job
         expect(locked_job).to eq([])
         expect(described_class::FindJobHitTotal.values[{ :queue => "default", :job_hit => "true" }]).to eq(0.0)
+      end
+    end
+
+    context "when passing run_at_cursor" do
+      it "passes run_at_cursor through to find_job_to_lock" do
+        run_at_cursor = '2024-01-01 00:00:00'
+        allow(Que).to receive(:execute).and_call_original
+        expect(Que).to receive(:execute).with(:find_job_to_lock, ["default", 0, run_at_cursor]).and_return([])
+        adapter.lock_job_with_lock_database("default", 0, run_at_cursor)
       end
     end
   end

--- a/spec/lib/que/adapters/active_record_with_lock_spec.rb
+++ b/spec/lib/que/adapters/active_record_with_lock_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Que::Adapters::ActiveRecordWithLock, :active_record_with_lock do
   end
 
   describe ".lock_job_with_lock_database" do
-    subject(:lock_job) { adapter.lock_job_with_lock_database("default", 0, '-infinity') }
+    subject(:lock_job) { adapter.lock_job_with_lock_database("default", 0, "-infinity") }
 
     context "with no jobs enqueued" do
       it "exists the loop and sets correct metric values" do
@@ -43,7 +43,7 @@ RSpec.describe Que::Adapters::ActiveRecordWithLock, :active_record_with_lock do
 
     context "when passing run_at_cursor" do
       it "passes run_at_cursor through to find_job_to_lock" do
-        run_at_cursor = '2024-01-01 00:00:00'
+        run_at_cursor = "2024-01-01 00:00:00"
         allow(Que).to receive(:execute).and_call_original
         expect(Que).to receive(:execute).with(:find_job_to_lock, ["default", 0, run_at_cursor]).and_return([])
         adapter.lock_job_with_lock_database("default", 0, run_at_cursor)

--- a/spec/lib/que/adapters/active_record_with_lock_spec.rb
+++ b/spec/lib/que/adapters/active_record_with_lock_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Que::Adapters::ActiveRecordWithLock, :active_record_with_lock do
   end
 
   describe ".lock_job_with_lock_database" do
-    subject(:lock_job) { adapter.lock_job_with_lock_database("default", 0, "-infinity") }
+    subject(:lock_job) { adapter.lock_job_with_lock_database("default", 0) }
 
     context "with no jobs enqueued" do
       it "exists the loop and sets correct metric values" do

--- a/spec/lib/que/locker_spec.rb
+++ b/spec/lib/que/locker_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe Que::Locker do
     end
 
     # Our tests are very concerned with which cursor we use and when
-    def expect_to_lock_with(cursor:, run_at_cursor: "-infinity")
-      expect(Que).to receive(:execute).with(:lock_job, [queue, cursor, run_at_cursor])
+    def expect_to_lock_with(cursor:, run_at_lower_bound: "-infinity")
+      expect(Que).to receive(:execute).with(:lock_job, [queue, cursor, run_at_lower_bound])
     end
 
     context "with no jobs to lock" do
@@ -142,20 +142,20 @@ RSpec.describe Que::Locker do
       end
 
       it "advances the run_at cursor to the previous job's run_at after locking" do
-        expect_to_lock_with(cursor: 0, run_at_cursor: "-infinity")
+        expect_to_lock_with(cursor: 0, run_at_lower_bound: "-infinity")
         expect_to_work(job_1)
 
-        expect_to_lock_with(cursor: job_1[:job_id], run_at_cursor: job_1[:run_at])
+        expect_to_lock_with(cursor: job_1[:job_id], run_at_lower_bound: job_1[:run_at])
         with_locked_job { |_job| }
       end
 
       it "resets both cursors when the expiry elapses" do
-        expect_to_lock_with(cursor: 0, run_at_cursor: "-infinity")
+        expect_to_lock_with(cursor: 0, run_at_lower_bound: "-infinity")
         expect_to_work(job_1)
 
         allow(Process).to receive(:clock_gettime).and_return(61)
 
-        expect_to_lock_with(cursor: 0, run_at_cursor: "-infinity")
+        expect_to_lock_with(cursor: 0, run_at_lower_bound: "-infinity")
         with_locked_job { |_job| }
       end
     end
@@ -170,10 +170,10 @@ RSpec.describe Que::Locker do
       end
 
       it "always passes -infinity as the run_at cursor regardless of jobs worked" do
-        expect_to_lock_with(cursor: 0, run_at_cursor: "-infinity")
+        expect_to_lock_with(cursor: 0, run_at_lower_bound: "-infinity")
         expect_to_work(job_1)
 
-        expect_to_lock_with(cursor: job_1[:job_id], run_at_cursor: "-infinity")
+        expect_to_lock_with(cursor: job_1[:job_id], run_at_lower_bound: "-infinity")
         with_locked_job { |_job| }
       end
     end

--- a/spec/lib/que/locker_spec.rb
+++ b/spec/lib/que/locker_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe Que::Locker do
     end
 
     # Our tests are very concerned with which cursor we use and when
-    def expect_to_lock_with(cursor:)
-      expect(Que).to receive(:execute).with(:lock_job, [queue, cursor])
+    def expect_to_lock_with(cursor:, run_at_cursor: '-infinity')
+      expect(Que).to receive(:execute).with(:lock_job, [queue, cursor, run_at_cursor])
     end
 
     context "with no jobs to lock" do
       it "scans entire table and calls block with nil job" do
-        expect(Que).to receive(:execute).with(:lock_job, [queue, 0])
+        expect(Que).to receive(:execute).with(:lock_job, [queue, 0, '-infinity'])
 
         with_locked_job do |job|
           expect(job).to be_nil
@@ -127,6 +127,56 @@ RSpec.describe Que::Locker do
       end
       # rubocop:enable RSpec/SubjectStub
       # rubocop:enable RSpec/InstanceVariable
+    end
+
+    context "with run_at_cursor enabled" do
+      subject(:locker) do
+        described_class.new(queue: queue, cursor_expiry: 60, run_at_cursor: true)
+      end
+
+      let!(:job_1) { FakeJob.enqueue(1, queue: queue, priority: 1).attrs }
+      let!(:job_2) { FakeJob.enqueue(2, queue: queue, priority: 2).attrs }
+
+      before do
+        allow(Process).to receive(:clock_gettime).and_return(0)
+        locker.instance_variable_get(:@queue_expires_at)[queue] = 60
+      end
+
+      it "advances the run_at cursor to the previous job's run_at after locking" do
+        expect_to_lock_with(cursor: 0, run_at_cursor: '-infinity')
+        expect_to_work(job_1)
+
+        expect_to_lock_with(cursor: job_1[:job_id], run_at_cursor: job_1[:run_at])
+        with_locked_job { |_job| }
+      end
+
+      it "resets both cursors when the expiry elapses" do
+        expect_to_lock_with(cursor: 0, run_at_cursor: '-infinity')
+        expect_to_work(job_1)
+
+        allow(Process).to receive(:clock_gettime).and_return(61)
+
+        expect_to_lock_with(cursor: 0, run_at_cursor: '-infinity')
+        with_locked_job { |_job| }
+      end
+    end
+
+    context "with run_at_cursor disabled (default)" do
+      let!(:job_1) { FakeJob.enqueue(1, queue: queue, priority: 1).attrs }
+      let(:cursor_expiry) { 60 }
+
+      before do
+        allow(Process).to receive(:clock_gettime).and_return(0)
+        locker.instance_variable_get(:@queue_expires_at)[queue] = 60
+      end
+
+      it "always passes -infinity as the run_at cursor regardless of jobs worked" do
+        expect_to_lock_with(cursor: 0, run_at_cursor: '-infinity')
+        expect_to_work(job_1)
+
+        expect_to_lock_with(cursor: job_1[:job_id], run_at_cursor: '-infinity')
+        with_locked_job { |_job| }
+      end
     end
   end
 end

--- a/spec/lib/que/locker_spec.rb
+++ b/spec/lib/que/locker_spec.rb
@@ -135,7 +135,6 @@ RSpec.describe Que::Locker do
       end
 
       let!(:job_1) { FakeJob.enqueue(1, queue: queue, priority: 1).attrs }
-      let!(:job_2) { FakeJob.enqueue(2, queue: queue, priority: 2).attrs }
 
       before do
         allow(Process).to receive(:clock_gettime).and_return(0)

--- a/spec/lib/que/locker_spec.rb
+++ b/spec/lib/que/locker_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe Que::Locker do
     end
 
     # Our tests are very concerned with which cursor we use and when
-    def expect_to_lock_with(cursor:, run_at_cursor: '-infinity')
+    def expect_to_lock_with(cursor:, run_at_cursor: "-infinity")
       expect(Que).to receive(:execute).with(:lock_job, [queue, cursor, run_at_cursor])
     end
 
     context "with no jobs to lock" do
       it "scans entire table and calls block with nil job" do
-        expect(Que).to receive(:execute).with(:lock_job, [queue, 0, '-infinity'])
+        expect(Que).to receive(:execute).with(:lock_job, [queue, 0, "-infinity"])
 
         with_locked_job do |job|
           expect(job).to be_nil
@@ -142,7 +142,7 @@ RSpec.describe Que::Locker do
       end
 
       it "advances the run_at cursor to the previous job's run_at after locking" do
-        expect_to_lock_with(cursor: 0, run_at_cursor: '-infinity')
+        expect_to_lock_with(cursor: 0, run_at_cursor: "-infinity")
         expect_to_work(job_1)
 
         expect_to_lock_with(cursor: job_1[:job_id], run_at_cursor: job_1[:run_at])
@@ -150,12 +150,12 @@ RSpec.describe Que::Locker do
       end
 
       it "resets both cursors when the expiry elapses" do
-        expect_to_lock_with(cursor: 0, run_at_cursor: '-infinity')
+        expect_to_lock_with(cursor: 0, run_at_cursor: "-infinity")
         expect_to_work(job_1)
 
         allow(Process).to receive(:clock_gettime).and_return(61)
 
-        expect_to_lock_with(cursor: 0, run_at_cursor: '-infinity')
+        expect_to_lock_with(cursor: 0, run_at_cursor: "-infinity")
         with_locked_job { |_job| }
       end
     end
@@ -170,10 +170,10 @@ RSpec.describe Que::Locker do
       end
 
       it "always passes -infinity as the run_at cursor regardless of jobs worked" do
-        expect_to_lock_with(cursor: 0, run_at_cursor: '-infinity')
+        expect_to_lock_with(cursor: 0, run_at_cursor: "-infinity")
         expect_to_work(job_1)
 
-        expect_to_lock_with(cursor: job_1[:job_id], run_at_cursor: '-infinity')
+        expect_to_lock_with(cursor: job_1[:job_id], run_at_cursor: "-infinity")
         with_locked_job { |_job| }
       end
     end

--- a/spec/lib/que/locker_spec.rb
+++ b/spec/lib/que/locker_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe Que::Locker do
     end
 
     # Our tests are very concerned with which cursor we use and when
-    def expect_to_lock_with(cursor:, run_at_lower_bound: "-infinity")
+    def expect_to_lock_with(cursor:, run_at_lower_bound: nil)
       expect(Que).to receive(:execute).with(:lock_job, [queue, cursor, run_at_lower_bound])
     end
 
     context "with no jobs to lock" do
       it "scans entire table and calls block with nil job" do
-        expect(Que).to receive(:execute).with(:lock_job, [queue, 0, "-infinity"])
+        expect(Que).to receive(:execute).with(:lock_job, [queue, 0, nil])
 
         with_locked_job do |job|
           expect(job).to be_nil
@@ -142,7 +142,7 @@ RSpec.describe Que::Locker do
       end
 
       it "advances the run_at cursor to the previous job's run_at after locking" do
-        expect_to_lock_with(cursor: 0, run_at_lower_bound: "-infinity")
+        expect_to_lock_with(cursor: 0, run_at_lower_bound: nil)
         expect_to_work(job_1)
 
         expect_to_lock_with(cursor: job_1[:job_id], run_at_lower_bound: job_1[:run_at])
@@ -150,12 +150,12 @@ RSpec.describe Que::Locker do
       end
 
       it "resets both cursors when the expiry elapses" do
-        expect_to_lock_with(cursor: 0, run_at_lower_bound: "-infinity")
+        expect_to_lock_with(cursor: 0, run_at_lower_bound: nil)
         expect_to_work(job_1)
 
         allow(Process).to receive(:clock_gettime).and_return(61)
 
-        expect_to_lock_with(cursor: 0, run_at_lower_bound: "-infinity")
+        expect_to_lock_with(cursor: 0, run_at_lower_bound: nil)
         with_locked_job { |_job| }
       end
     end
@@ -170,10 +170,10 @@ RSpec.describe Que::Locker do
       end
 
       it "always passes -infinity as the run_at cursor regardless of jobs worked" do
-        expect_to_lock_with(cursor: 0, run_at_lower_bound: "-infinity")
+        expect_to_lock_with(cursor: 0, run_at_lower_bound: nil)
         expect_to_work(job_1)
 
-        expect_to_lock_with(cursor: job_1[:job_id], run_at_lower_bound: "-infinity")
+        expect_to_lock_with(cursor: job_1[:job_id], run_at_lower_bound: nil)
         with_locked_job { |_job| }
       end
     end

--- a/spec/lib/que/worker_spec.rb
+++ b/spec/lib/que/worker_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Que::Worker do
           FakeJob.enqueue(1)
 
           expect(Que).
-            to receive(:execute).with(:lock_job, ["default", 0]).and_raise(PG::Error)
+            to receive(:execute).with(:lock_job, ["default", 0, "-infinity"]).and_raise(PG::Error)
           expect(work).to eq(:postgres_error)
         end
       end
@@ -219,7 +219,7 @@ RSpec.describe Que::Worker do
       context "when postgres raises a bad connection error while processing a job" do
         before do
           allow(Que).to receive(:execute).
-            with(:lock_job, ["default", 0]).
+            with(:lock_job, ["default", 0, "-infinity"]).
             and_raise(PG::ConnectionBad)
 
           # Ensure we don't have any currently leased connections, since in a thread
@@ -246,7 +246,7 @@ RSpec.describe Que::Worker do
           FakeJob.enqueue(1)
 
           expect(Que).
-            to receive(:execute).with(:lock_job, ["default", 0]).
+            to receive(:execute).with(:lock_job, ["default", 0, "-infinity"]).
             and_raise(ActiveRecord::ConnectionTimeoutError)
           expect(work).to eq(:postgres_error)
         end
@@ -257,7 +257,7 @@ RSpec.describe Que::Worker do
           FakeJob.enqueue(1)
 
           expect(Que).
-            to receive(:execute).with(:lock_job, ["default", 0]).
+            to receive(:execute).with(:lock_job, ["default", 0, "-infinity"]).
             and_raise(ActiveRecord::ConnectionNotEstablished)
           expect(work).to eq(:postgres_error)
         end
@@ -286,18 +286,18 @@ RSpec.describe Que::Worker do
     it "is false after a postgres error" do
       FakeJob.enqueue(1)
       expect(Que).
-        to receive(:execute).with(:lock_job, ["default", 0]).and_raise(PG::Error)
+        to receive(:execute).with(:lock_job, ["default", 0, "-infinity"]).and_raise(PG::Error)
       worker.work
       expect(worker).to_not be_healthy
     end
 
     it "recovers once work succeeds after a postgres error" do
       expect(Que).
-        to receive(:execute).with(:lock_job, ["default", 0]).and_raise(PG::Error)
+        to receive(:execute).with(:lock_job, ["default", 0, "-infinity"]).and_raise(PG::Error)
       worker.work
       expect(worker).to_not be_healthy
 
-      allow(Que).to receive(:execute).with(:lock_job, ["default", 0]).and_return([])
+      allow(Que).to receive(:execute).with(:lock_job, ["default", 0, "-infinity"]).and_return([])
       worker.work # no job found, returns :job_not_found
       expect(worker).to be_healthy
     end

--- a/spec/lib/que/worker_spec.rb
+++ b/spec/lib/que/worker_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Que::Worker do
           FakeJob.enqueue(1)
 
           expect(Que).
-            to receive(:execute).with(:lock_job, ["default", 0, "-infinity"]).and_raise(PG::Error)
+            to receive(:execute).with(:lock_job, ["default", 0, nil]).and_raise(PG::Error)
           expect(work).to eq(:postgres_error)
         end
       end
@@ -219,7 +219,7 @@ RSpec.describe Que::Worker do
       context "when postgres raises a bad connection error while processing a job" do
         before do
           allow(Que).to receive(:execute).
-            with(:lock_job, ["default", 0, "-infinity"]).
+            with(:lock_job, ["default", 0, nil]).
             and_raise(PG::ConnectionBad)
 
           # Ensure we don't have any currently leased connections, since in a thread
@@ -246,7 +246,7 @@ RSpec.describe Que::Worker do
           FakeJob.enqueue(1)
 
           expect(Que).
-            to receive(:execute).with(:lock_job, ["default", 0, "-infinity"]).
+            to receive(:execute).with(:lock_job, ["default", 0, nil]).
             and_raise(ActiveRecord::ConnectionTimeoutError)
           expect(work).to eq(:postgres_error)
         end
@@ -257,7 +257,7 @@ RSpec.describe Que::Worker do
           FakeJob.enqueue(1)
 
           expect(Que).
-            to receive(:execute).with(:lock_job, ["default", 0, "-infinity"]).
+            to receive(:execute).with(:lock_job, ["default", 0, nil]).
             and_raise(ActiveRecord::ConnectionNotEstablished)
           expect(work).to eq(:postgres_error)
         end
@@ -286,18 +286,18 @@ RSpec.describe Que::Worker do
     it "is false after a postgres error" do
       FakeJob.enqueue(1)
       expect(Que).
-        to receive(:execute).with(:lock_job, ["default", 0, "-infinity"]).and_raise(PG::Error)
+        to receive(:execute).with(:lock_job, ["default", 0, nil]).and_raise(PG::Error)
       worker.work
       expect(worker).to_not be_healthy
     end
 
     it "recovers once work succeeds after a postgres error" do
       expect(Que).
-        to receive(:execute).with(:lock_job, ["default", 0, "-infinity"]).and_raise(PG::Error)
+        to receive(:execute).with(:lock_job, ["default", 0, nil]).and_raise(PG::Error)
       worker.work
       expect(worker).to_not be_healthy
 
-      allow(Que).to receive(:execute).with(:lock_job, ["default", 0, "-infinity"]).and_return([])
+      allow(Que).to receive(:execute).with(:lock_job, ["default", 0, nil]).and_return([])
       worker.work # no job found, returns :job_not_found
       expect(worker).to be_healthy
     end


### PR DESCRIPTION
This additional cursor can lead to more dead tuples/tombstones being skipped while acquiring locks on jobs. The cursor is optional, configured behind the `run_at_cursor` flag when starting a worker. If not specified the `run_at` clause will always be set to `-infinity`, performing the same as if it was not present.